### PR TITLE
Disable same-origin /__api proxy and default browser API to loopback

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Default URLs:
 If port 3000 is busy, run the frontend manually on another port:
 
 ```bash
-PORT=3001 BUN_PUBLIC_API_BASE_URL=http://127.0.0.1:8000 bun --hot src/index.ts
+PORT=3001 BUN_PUBLIC_BROWSER_API_BASE_URL=http://127.0.0.1:8000 bun --hot src/index.ts
 ```
 
 Run the local install doctor any time an operator changes machines, ports, OCR tooling, auth settings, or model runtimes:
@@ -139,8 +139,10 @@ Common environment variables:
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `BUN_PUBLIC_API_BASE_URL` | `http://127.0.0.1:8000` on local UI hosts | Frontend API target |
-| `VITE_API_BASE_URL` | Same as above | Vite-compatible API target |
+| `BUN_PUBLIC_BROWSER_API_BASE_URL` | `http://127.0.0.1:8000` on local UI hosts | Browser API target for UI requests |
+| `VITE_BROWSER_API_BASE_URL` | Same as above | Vite-compatible browser API target |
+| `BUN_PUBLIC_API_BASE_URL` | `http://127.0.0.1:8000` on local UI hosts | Server-side target for the limited legacy `/api/*` proxy |
+| `VITE_API_BASE_URL` | Same as above | Vite-compatible server-side proxy target |
 | `JR_DEMO_MODE` | unset | Use disposable demo storage when set to `1`, `true`, or `yes` |
 | `JR_DATA_DIR` | unset | Explicit local data directory |
 | `AUTORAG_AUTH_ENABLED` | `false` | Require API keys |
@@ -269,7 +271,7 @@ curl http://127.0.0.1:8000/documents
 
 | Issue | Fix |
 | --- | --- |
-| UI cannot reach API | Confirm FastAPI is on port 8000 and set `BUN_PUBLIC_API_BASE_URL=http://127.0.0.1:8000`. |
+| UI cannot reach API | Confirm FastAPI is on port 8000 and set `BUN_PUBLIC_BROWSER_API_BASE_URL=http://127.0.0.1:8000`. |
 | Provider list is empty | Start Ollama or LM Studio, then rescan providers. |
 | Query returns context summary only | Apply a provider in Configuration. |
 | PDF upload has no text | Install Poppler and Tesseract, then restart the API. |
@@ -281,7 +283,7 @@ curl http://127.0.0.1:8000/documents
 1. Build the UI with `bun run build`.
 2. Serve `dist/` behind a static server.
 3. Deploy the FastAPI app behind HTTPS.
-4. Set `BUN_PUBLIC_API_BASE_URL` to the API origin at build/runtime.
+4. Set `BUN_PUBLIC_BROWSER_API_BASE_URL` to the public API origin at build/runtime.
 5. Enable `AUTORAG_AUTH_ENABLED=true`.
 6. Set `AUTORAG_API_KEYS`.
 7. Set exact `AUTORAG_ALLOWED_ORIGINS`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - api
     environment:
       BUN_PUBLIC_API_BASE_URL: http://api:8000
+      BUN_PUBLIC_BROWSER_API_BASE_URL: http://127.0.0.1:8000
 
 volumes:
   api-data:

--- a/scripts/container-build-smoke.sh
+++ b/scripts/container-build-smoke.sh
@@ -75,10 +75,11 @@ docker run -d --rm \
   --name "${WEB_CONTAINER}" \
   -e "BUN_PUBLIC_API_BASE_URL=http://${API_CONTAINER}:8000" \
   -e "VITE_API_BASE_URL=http://${API_CONTAINER}:8000" \
+  -e "BUN_PUBLIC_BROWSER_API_BASE_URL=http://127.0.0.1:${API_PORT}" \
+  -e "VITE_BROWSER_API_BASE_URL=http://127.0.0.1:${API_PORT}" \
   -p "127.0.0.1:${WEB_PORT}:3000" \
   "${WEB_IMAGE}" >/dev/null
 wait_for_url "http://127.0.0.1:${WEB_PORT}/" "${TMP_DIR}/web.html" "Web"
-wait_for_url "http://127.0.0.1:${WEB_PORT}/__api/healthz" "${TMP_DIR}/web-proxy-healthz.json" "Web API proxy"
 
 if ! grep -q '<div id="root"></div>' "${TMP_DIR}/web.html"; then
   echo "web root container was not served" >&2

--- a/scripts/container-manifest-check.sh
+++ b/scripts/container-manifest-check.sh
@@ -60,7 +60,6 @@ for required in (
     "docker network create",
     "/healthz",
     "/readyz",
-    "/__api/healthz",
     "docker build -t \"${WEB_IMAGE}\"",
     "web-assets.txt",
 ):

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -42,6 +42,8 @@ echo "Starting web UI on http://localhost:${WEB_PORT}..."
 cd "${ROOT_DIR}"
 BUN_PUBLIC_API_BASE_URL="${BUN_PUBLIC_API_BASE_URL:-http://${API_HOST}:${API_PORT}}" \
   VITE_API_BASE_URL="${VITE_API_BASE_URL:-http://${API_HOST}:${API_PORT}}" \
+  BUN_PUBLIC_BROWSER_API_BASE_URL="${BUN_PUBLIC_BROWSER_API_BASE_URL:-http://${API_HOST}:${API_PORT}}" \
+  VITE_BROWSER_API_BASE_URL="${VITE_BROWSER_API_BASE_URL:-http://${API_HOST}:${API_PORT}}" \
   PORT="${WEB_PORT}" \
   env \
     -u npm_command \

--- a/scripts/install-smoke.sh
+++ b/scripts/install-smoke.sh
@@ -109,6 +109,8 @@ API_PID="$!"
     HOME="${HOME}" \
     BUN_PUBLIC_API_BASE_URL="http://127.0.0.1:${API_PORT}" \
     VITE_API_BASE_URL="http://127.0.0.1:${API_PORT}" \
+    BUN_PUBLIC_BROWSER_API_BASE_URL="http://127.0.0.1:${API_PORT}" \
+    VITE_BROWSER_API_BASE_URL="http://127.0.0.1:${API_PORT}" \
     PORT="${WEB_PORT}" \
     bun --hot src/index.ts
 ) > "${TMP_DIR}/web.log" 2>&1 &
@@ -125,9 +127,8 @@ for _ in {1..80}; do
   api_code="$(curl -sS -o "${TMP_DIR}/api-health.json" -w '%{http_code}' "http://127.0.0.1:${API_PORT}/healthz" 2>/dev/null || true)"
   web_code="$(curl -sS -o "${TMP_DIR}/web.html" -w '%{http_code}' "http://127.0.0.1:${WEB_PORT}/" 2>/dev/null || true)"
   proxy_body="$(curl -sS "http://127.0.0.1:${WEB_PORT}/api/install-smoke?check=proxy" 2>/dev/null || true)"
-  same_origin_body="$(curl -sS "http://127.0.0.1:${WEB_PORT}/__api/config" 2>/dev/null || true)"
-  if [[ "${api_code}" == "200" && "${web_code}" == "200" && "${proxy_body}" == *'"ok": true'* && "${proxy_body}" == *'/api/install-smoke?check=proxy'* && "${same_origin_body}" == *'"profile": "Default"'* ]]; then
-    printf 'install_smoke=pass api=%s web=%s proxy=%s same_origin=%s\n' "${api_code}" "${web_code}" "${proxy_body}" "${same_origin_body}"
+  if [[ "${api_code}" == "200" && "${web_code}" == "200" && "${proxy_body}" == *'"ok": true'* && "${proxy_body}" == *'/api/install-smoke?check=proxy'* ]]; then
+    printf 'install_smoke=pass api=%s web=%s proxy=%s\n' "${api_code}" "${web_code}" "${proxy_body}"
     exit 0
   fi
   sleep 0.25

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,13 +7,10 @@ const apiBaseUrl = (
   "http://127.0.0.1:8000"
 ).replace(/\/+$/, "");
 
-const proxyApiRequest = async (req: Request, prefix: string) => {
+const proxyApiRequest = async (req: Request) => {
   const url = new URL(req.url);
-  const path = prefix && url.pathname.startsWith(prefix)
-    ? url.pathname.slice(prefix.length) || "/"
-    : url.pathname;
   try {
-    return await fetch(apiBaseUrl + path + url.search, {
+    return await fetch(apiBaseUrl + url.pathname + url.search, {
       method: req.method,
       headers: req.headers,
       body: req.body,
@@ -31,13 +28,15 @@ const server = serve({
 
     "/HWC-Icon.png": Bun.file(new URL("./HWC-Icon.png", import.meta.url)),
 
-    // Same-origin proxy for browser clients. The prefix is stripped before the
-    // request reaches FastAPI, so /__api/config maps to /config.
-    "/__api/*": (req) => proxyApiRequest(req, "/__api"),
+    // Do not expose bare FastAPI routes through the web server. The UI should
+    // call the configured browser API origin directly instead.
+    "/__api/*": () => new Response("API proxy disabled", { status: 404 }),
 
-    // Preserve the legacy /api proxy for backend routes that already live under
-    // FastAPI's /api prefix, such as /api/artifacts/status.
-    "/api/*": (req) => proxyApiRequest(req, ""),
+    // Preserve the legacy /api proxy only for backend routes that already live
+    // under FastAPI's /api prefix, such as /api/artifacts/status. Bare backend
+    // routes must be reached through the configured browser API origin instead
+    // of being exposed through the web server.
+    "/api/*": (req) => proxyApiRequest(req),
 
     "/api/hello": {
       async GET(req) {

--- a/src/lib/api-url.test.ts
+++ b/src/lib/api-url.test.ts
@@ -1,19 +1,19 @@
 import { describe, expect, test } from "bun:test";
 
-import { API_PROXY_PREFIX, buildApiUrl, normalizeApiBaseUrl } from "./api-url";
+import { DEFAULT_API_BASE_URL, buildApiUrl, normalizeApiBaseUrl } from "./api-url";
 
 describe("api url helpers", () => {
-  test("defaults to the same-origin backend proxy", () => {
-    expect(normalizeApiBaseUrl("")).toBe(API_PROXY_PREFIX);
-    expect(normalizeApiBaseUrl(undefined)).toBe(API_PROXY_PREFIX);
+  test("defaults to the local FastAPI origin instead of a same-origin backend proxy", () => {
+    expect(normalizeApiBaseUrl("")).toBe(DEFAULT_API_BASE_URL);
+    expect(normalizeApiBaseUrl(undefined)).toBe(DEFAULT_API_BASE_URL);
   });
 
   test("joins direct API origins and paths", () => {
     expect(buildApiUrl("http://127.0.0.1:8018/", "/healthz")).toBe("http://127.0.0.1:8018/healthz");
   });
 
-  test("joins proxy base and backend routes without hiding API-prefixed paths", () => {
-    expect(buildApiUrl(API_PROXY_PREFIX, "/config")).toBe("/__api/config");
-    expect(buildApiUrl(API_PROXY_PREFIX, "/api/artifacts/status")).toBe("/__api/api/artifacts/status");
+  test("joins configured API bases and backend routes without rewriting paths", () => {
+    expect(buildApiUrl("http://127.0.0.1:8000", "/config")).toBe("http://127.0.0.1:8000/config");
+    expect(buildApiUrl("http://127.0.0.1:8000", "/api/artifacts/status")).toBe("http://127.0.0.1:8000/api/artifacts/status");
   });
 });

--- a/src/lib/api-url.ts
+++ b/src/lib/api-url.ts
@@ -1,8 +1,8 @@
-export const API_PROXY_PREFIX = "/__api";
+export const DEFAULT_API_BASE_URL = "http://127.0.0.1:8000";
 
 export function normalizeApiBaseUrl(value?: string) {
   const trimmed = value?.trim().replace(/\/+$/, "");
-  return trimmed || API_PROXY_PREFIX;
+  return trimmed || DEFAULT_API_BASE_URL;
 }
 
 export function buildApiUrl(baseUrl: string | undefined, path: string) {
@@ -16,7 +16,7 @@ export function resolveDefaultApiBaseUrl() {
     (import.meta.env?.BUN_PUBLIC_BROWSER_API_BASE_URL as string | undefined) ||
     (import.meta.env?.VITE_BROWSER_API_BASE_URL as string | undefined);
   if (envBase) {
-    return normalizeApiBaseUrl(envBase.replace("http://localhost:8000", "http://127.0.0.1:8000"));
+    return normalizeApiBaseUrl(envBase.replace("http://localhost:8000", DEFAULT_API_BASE_URL));
   }
-  return API_PROXY_PREFIX;
+  return DEFAULT_API_BASE_URL;
 }


### PR DESCRIPTION
### Motivation
- Prevent the web server from acting as a same-origin reverse proxy that strips `/__api` and exposes bare FastAPI routes reachable to remote clients.
- Restore the deployment boundary by making the browser-facing UI call the configured API origin instead of the web process by default.
- Keep the limited legacy `/api/*` proxy for routes that intentionally live under FastAPI's `/api` prefix.

### Description
- Return `404` for the `/__api/*` route in `src/index.ts` and preserve only the legacy `/api/*` proxy while simplifying `proxyApiRequest` to forward requests to the configured server-side API base URL.
- Change frontend API helpers in `src/lib/api-url.ts` to default browser API requests to `http://127.0.0.1:8000` and to honor `BUN_PUBLIC_BROWSER_API_BASE_URL` / `VITE_BROWSER_API_BASE_URL` environment variables instead of defaulting to a same-origin proxy.
- Update unit tests in `src/lib/api-url.test.ts` to assert the new default behavior and path-joining semantics.
- Update dev/install/container scripts, `docker-compose.yml`, `scripts/container-manifest-check.sh`, and `README.md` to use the new browser API environment variables and to remove expectations that the web process provides the `/__api` health endpoint.

### Testing
- Ran `bun test src/lib/api-url.test.ts` and the tests passed (3 tests, 0 failures).
- Ran `bash scripts/container-manifest-check.sh` and it passed (`container_manifest=pass`).
- Ran the focused smoke/test sequence `git diff --check && bash scripts/container-manifest-check.sh && bun test src/lib/api-url.test.ts` and the sequence completed successfully for the modified checks and unit tests.
- Full `bun test` and `bun run typecheck` were blocked/failed in this environment due to missing node modules and dependencies (attempted `bun install` failed with registry errors), so broader test/typecheck runs were not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18841e666c83279d64e5788886a347)