### PR TITLE
Require authentication for exposed API deployments

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -13,7 +13,9 @@ WORKDIR /app
 COPY pyproject.toml uv.lock ./
 RUN uv sync --locked --no-dev --no-install-project
 
-ENV PATH="/app/.venv/bin:${PATH}"
+ENV PATH="/app/.venv/bin:${PATH}" \
+    AUTORAG_EXPOSE=true \
+    AUTORAG_AUTH_ENABLED=true
 
 COPY app ./app
 

--- a/api/tests/test_security_exposure.py
+++ b/api/tests/test_security_exposure.py
@@ -1,0 +1,78 @@
+"""Regression tests for exposed API authentication defaults."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from app.core import auth as auth_module
+from app.core.security_middleware import verify_api_key
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _reset_auth() -> None:
+    auth_module._auth_instance = None
+
+
+def _request(path: str) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": path,
+            "headers": [],
+            "server": ("testserver", 80),
+            "scheme": "http",
+            "client": ("203.0.113.10", 4444),
+        }
+    )
+
+
+def test_docker_image_enables_exposed_authenticated_mode() -> None:
+    dockerfile = (REPO_ROOT / "api" / "Dockerfile").read_text()
+
+    assert "AUTORAG_EXPOSE=true" in dockerfile
+    assert "AUTORAG_AUTH_ENABLED=true" in dockerfile
+
+
+def test_compose_requires_api_keys_for_published_api() -> None:
+    compose = (REPO_ROOT / "docker-compose.yml").read_text()
+
+    assert 'AUTORAG_EXPOSE: "true"' in compose
+    assert 'AUTORAG_AUTH_ENABLED: "true"' in compose
+    assert "AUTORAG_API_KEYS: ${AUTORAG_API_KEYS:?" in compose
+
+
+@pytest.mark.asyncio
+async def test_config_route_rejects_missing_api_key_when_auth_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTORAG_AUTH_ENABLED", "true")
+    monkeypatch.setenv("AUTORAG_API_KEYS", "test-admin-key")
+    monkeypatch.delenv("AUTORAG_EXPOSE", raising=False)
+    _reset_auth()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await verify_api_key(_request("/config"), api_key=None)
+
+    assert exc_info.value.status_code == 401
+
+    _reset_auth()
+
+
+@pytest.mark.asyncio
+async def test_exposed_mode_fails_closed_without_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTORAG_EXPOSE", "true")
+    monkeypatch.setenv("AUTORAG_AUTH_ENABLED", "false")
+    monkeypatch.delenv("AUTORAG_API_KEYS", raising=False)
+    _reset_auth()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await verify_api_key(_request("/documents"), api_key=None)
+
+    assert exc_info.value.status_code == 503
+
+    _reset_auth()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ services:
       - "8000:8000"
     environment:
       JR_DATA_DIR: /data
+      AUTORAG_EXPOSE: "true"
+      AUTORAG_AUTH_ENABLED: "true"
+      AUTORAG_API_KEYS: ${AUTORAG_API_KEYS:?Set AUTORAG_API_KEYS before starting the exposed API}
     volumes:
       - api-data:/data
   web:


### PR DESCRIPTION
### Motivation
- Containerized deployments previously bound the API to `0.0.0.0:8000` and published port 8000 without enforcing authentication, exposing sensitive admin, document, query, and trace endpoints.
- The change makes image and compose defaults fail-closed when the service is published to the host, preventing accidental unauthenticated exposure.

### Description
- Set `AUTORAG_EXPOSE=true` and `AUTORAG_AUTH_ENABLED=true` in `api/Dockerfile` so the container image runs in exposed/authenticated mode by default.
- Update `docker-compose.yml` to set `AUTORAG_EXPOSE: "true"`, `AUTORAG_AUTH_ENABLED: "true"`, and require `AUTORAG_API_KEYS` via `${AUTORAG_API_KEYS:?...}` when publishing port 8000.
- Add regression tests at `api/tests/test_security_exposure.py` that assert the Docker/compose defaults and verify `verify_api_key` rejects unauthenticated calls when auth is enabled or exposed mode is misconfigured.

### Testing
- Ran `cd api && uv run pytest tests/test_security_exposure.py`, which passed (4 tests).
- Ran `cd api && uv run pytest tests/test_smoke.py tests/test_security_exposure.py`, which passed (9 tests in total).
- Ran `cd api && uv run ruff check app tests/test_security_exposure.py`, which completed without issues.
- Attempted `docker compose config` for full compose validation but Docker is not installed in the execution environment so this step could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18862376a08327be829572f48b022b)