### PR TITLE
Require admin scope for experiments API

### DIFF
--- a/api/app/core/security_middleware.py
+++ b/api/app/core/security_middleware.py
@@ -57,6 +57,7 @@ ROUTE_SCOPES = {
     "/query": "read",
     "/documents": "write",
     "/config": "admin",
+    "/experiments": "admin",
     "/evaluation": "read",
     "/providers": "read",
     "/security": "read",

--- a/api/tests/api/test_quality_endpoints.py
+++ b/api/tests/api/test_quality_endpoints.py
@@ -8,7 +8,9 @@ from fastapi.testclient import TestClient
 from app.core.config_store import ConfigStore
 from app.core.documents import Document, DocumentStore
 from app.core.experiments import ExperimentConfig, ExperimentRunStore, LocalExperimentRunner
+from app.core.auth import APIKeyAuth
 from app.core.ingest import IngestPipeline
+from app.core.security_middleware import _resolve_required_scope
 from app.main import app
 from app.routers.config import quality_recommendations
 from app.services import get_container
@@ -75,6 +77,19 @@ def test_quality_endpoints_without_retrieval_startup(tmp_path: Path) -> None:
         assert container.applied is True
     finally:
         app.dependency_overrides.clear()
+
+
+def test_experiments_endpoints_require_admin_scope() -> None:
+    auth = APIKeyAuth(enabled=True)
+    read_key, _ = auth.generate_key("reader", scopes=["read"])
+    admin_key, _ = auth.generate_key("admin", scopes=["admin"])
+
+    assert _resolve_required_scope("/experiments", "GET") == "admin"
+    assert _resolve_required_scope("/experiments", "POST") == "admin"
+    assert _resolve_required_scope("/experiments/run-1", "GET") == "admin"
+    assert _resolve_required_scope("/experiments/run-1/promote", "POST") == "admin"
+    assert auth.verify(read_key, required_scope=_resolve_required_scope("/experiments/run-1/promote", "POST")) is False
+    assert auth.verify(admin_key, required_scope=_resolve_required_scope("/experiments/run-1/promote", "POST")) is True
 
 
 def test_document_preview_falls_back_from_stored_text(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- The `/experiments` router was registered behind generic API-key verification but not mapped to a required scope, allowing any valid (non-admin) API key to view experiment `config_snapshot` and invoke the `promote` endpoint to mutate runtime configuration.
- The change hardens authorization by making experiment endpoints require the same `admin` scope as other sensitive routes like `/config`.

### Description
- Add `/experiments`: `admin` to `ROUTE_SCOPES` in `api/app/core/security_middleware.py` so `_resolve_required_scope` returns `admin` for experiment routes.
- Add `test_experiments_endpoints_require_admin_scope` to `api/tests/api/test_quality_endpoints.py` which asserts route resolution for list/create/detail/promote and verifies that a `read` key fails while an `admin` key succeeds.
- Import `APIKeyAuth` and `_resolve_required_scope` in the test to generate keys and assert authorization behavior.

### Testing
- Ran `python -m compileall -q api/app/core/security_middleware.py api/tests/api/test_quality_endpoints.py` and it completed successfully.
- Ran `python -m ruff check api/app/core/security_middleware.py api/tests/api/test_quality_endpoints.py` and lint checks passed.
- An initial direct `pytest` invocation failed in the environment with `ModuleNotFoundError: No module named 'fastapi'`, after which tests were executed using the project test environment; `cd api && uv run pytest tests/api/test_quality_endpoints.py::test_experiments_endpoints_require_admin_scope` passed.
- Ran the full file `cd api && uv run pytest tests/api/test_quality_endpoints.py` and all tests in that file passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1884948f0c832781defb685cab2ad3)