### PR TITLE
Fix local-only provider URL enforcement

### DIFF
--- a/api/app/routers/config.py
+++ b/api/app/routers/config.py
@@ -77,6 +77,7 @@ def update_config(
             if not profile:
                 raise HTTPException(status_code=404, detail=f"Profile '{active_profile}' not found")
             cfg.provider = profile.provider
+            cfg = AppConfig.model_validate(cfg.model_dump())
         sanitized = container.prepare_config_for_storage(cfg)
         stored = container.config_store.write(sanitized)
         container.apply_config(stored)

--- a/api/app/schemas/config.py
+++ b/api/app/schemas/config.py
@@ -51,16 +51,17 @@ class OCRPolicy(str, Enum):
 
 
 def _is_local_url(value: str) -> bool:
-    lowered = value.strip().lower()
-    return (
-        lowered.startswith("http://localhost")
-        or lowered.startswith("http://127.0.0.1")
-        or lowered.startswith("http://0.0.0.0")
-        or lowered.startswith("http://[::1]")
-        or lowered.startswith("https://localhost")
-        or lowered.startswith("https://127.0.0.1")
-        or lowered.startswith("https://[::1]")
-    )
+    parsed = urlparse(value.strip())
+    host = (parsed.hostname or "").strip().lower()
+    if not host:
+        return False
+    if host == "localhost":
+        return True
+    try:
+        parsed_ip = ip_address(host)
+    except ValueError:
+        return False
+    return parsed_ip.is_loopback or parsed_ip.is_unspecified
 
 
 def _is_client_owned_url(value: str) -> bool:
@@ -676,6 +677,12 @@ class AppConfig(BaseModel):
         if self.deployment_profile == DeploymentProfile.LOCAL_ONLY:
             if self.provider and not _is_local_url(str(self.provider.base_url)):
                 raise ValueError("Local-only mode requires a localhost or loopback provider URL.")
+            for profile in self.provider_profiles:
+                if not _is_local_url(str(profile.provider.base_url)):
+                    raise ValueError(
+                        f"Provider profile '{profile.name}' is not compatible with local-only mode: "
+                        "provider URL must be localhost or loopback."
+                    )
 
             for name, backend in self.backends.items():
                 if not backend.enabled:

--- a/api/tests/api/test_endpoints.py
+++ b/api/tests/api/test_endpoints.py
@@ -69,6 +69,35 @@ def test_config_rejects_cloud_provider_in_local_only_mode(client: TestClient) ->
     assert "local-only" in str(detail).lower()
 
 
+def test_config_rejects_remote_active_profile_in_local_only_mode(client: TestClient) -> None:
+    resp = client.get("/config")
+    assert resp.status_code == 200
+    config = resp.json()
+    config["deployment_profile"] = "local_only"
+    config["provider"] = {
+        "name": "Ollama",
+        "base_url": "http://localhost:11434",
+        "generator_model": "llama3",
+    }
+    config["provider_profiles"] = [
+        {
+            "name": "remote",
+            "provider": {
+                "name": "Attacker",
+                "base_url": "https://attacker.example/v1",
+                "generator_model": "remote-model",
+            },
+        }
+    ]
+
+    update = client.put("/config?active_profile=remote", json=config)
+    assert update.status_code in {400, 422}
+    detail = update.json()["detail"]
+    if isinstance(detail, list):
+        detail = " ".join(str(item) for item in detail)
+    assert "local-only" in str(detail).lower()
+
+
 def test_policy_endpoint_exposes_client_data_policy(client: TestClient) -> None:
     resp = client.get("/config/policy")
     assert resp.status_code == 200

--- a/api/tests/test_vnext_expansion.py
+++ b/api/tests/test_vnext_expansion.py
@@ -409,6 +409,51 @@ class TestLocalFirstConfig:
                 },
             )
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://localhost.evil.example/v1",
+            "http://localhost@evil.example/v1",
+            "http://127.0.0.1.evil.example/v1",
+            "https://127.0.0.1@evil.example/v1",
+        ],
+    )
+    def test_local_only_rejects_host_confusion_provider_urls(self, url):
+        from app.schemas.config import AppConfig
+
+        with pytest.raises(ValueError, match="localhost or loopback"):
+            AppConfig(
+                deployment_profile="local_only",
+                provider={
+                    "name": "Attacker",
+                    "base_url": url,
+                    "generator_model": "remote-model",
+                },
+            )
+
+    def test_local_only_rejects_remote_provider_profiles(self):
+        from app.schemas.config import AppConfig
+
+        with pytest.raises(ValueError, match="Provider profile 'remote'.*local-only mode"):
+            AppConfig(
+                deployment_profile="local_only",
+                provider={
+                    "name": "Ollama",
+                    "base_url": "http://localhost:11434",
+                    "generator_model": "llama3",
+                },
+                provider_profiles=[
+                    {
+                        "name": "remote",
+                        "provider": {
+                            "name": "Attacker",
+                            "base_url": "https://attacker.example/v1",
+                            "generator_model": "remote-model",
+                        },
+                    }
+                ],
+            )
+
 
 class TestConversationMemory:
     def test_record_exchange_writes_episodic_memory_for_substantive_turns(self):


### PR DESCRIPTION
### Motivation
- The local-only deployment profile could be bypassed because host checks used naive string prefixes and provider profiles were not validated, allowing remote providers to be activated while `deployment_profile` remained `local_only`.
- This change closes the policy gap to prevent exfiltration of prompts, API keys, or OCR images to attacker-controlled endpoints.

### Description
- Replace prefix-based local URL detection with a parsed-host check that uses `urlparse` and `ip_address` to accept only `localhost` hostnames or loopback/unspecified IP addresses in `api/app/schemas/config.py` via `_is_local_url`.
- Enforce local-only constraints on every `provider_profiles[*].provider` inside `AppConfig._validate_local_first_policy` so imported/inactive profiles cannot contain remote provider URLs (`api/app/schemas/config.py`).
- Revalidate the config after applying an `active_profile` in the config API handler to ensure post-mutation policy checks run before persisting or applying the configuration by calling `AppConfig.model_validate(cfg.model_dump())` in `api/app/routers/config.py`.
- Add regression tests covering host-confusion provider URLs and activation of a remote profile via the API in `api/tests/test_vnext_expansion.py` and `api/tests/api/test_endpoints.py`.

### Testing
- Ran targeted unit tests inside the `api` environment with `cd api && uv run pytest tests/test_vnext_expansion.py::TestLocalFirstConfig tests/api/test_endpoints.py::test_config_rejects_cloud_provider_in_local_only_mode tests/api/test_endpoints.py::test_config_rejects_remote_active_profile_in_local_only_mode`, and the test run passed (`8 passed`).
- Earlier direct `pytest` invocations from the repo root failed due to missing project dependencies like `fastapi`/`pydantic`, which is expected in this environment, so the validated run used the `api` workflow helper (`uv run`).
- Performed static checks with `cd api && uv run ruff check app/schemas/config.py app/routers/config.py tests/test_vnext_expansion.py tests/api/test_endpoints.py` and `ruff` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18842221848327a72efd2795baeca3)