### PR TITLE
Validate and apply sanitized config before persisting to prevent invalid provider persistence

### DIFF
--- a/api/app/routers/config.py
+++ b/api/app/routers/config.py
@@ -78,8 +78,8 @@ def update_config(
                 raise HTTPException(status_code=404, detail=f"Profile '{active_profile}' not found")
             cfg.provider = profile.provider
         sanitized = container.prepare_config_for_storage(cfg)
+        container.apply_config(sanitized)
         stored = container.config_store.write(sanitized)
-        container.apply_config(stored)
         return stored
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e)) from e

--- a/api/tests/api/test_config_router.py
+++ b/api/tests/api/test_config_router.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from app.core.providers import ProviderError
+from app.routers.config import update_config
+from app.schemas.config import AppConfig, DeploymentProfile, ProviderConfig
+
+
+class RecordingConfigStore:
+    def __init__(self) -> None:
+        self.writes: list[AppConfig] = []
+
+    def read(self) -> AppConfig:
+        return AppConfig()
+
+    def write(self, cfg: AppConfig) -> AppConfig:
+        self.writes.append(cfg)
+        return cfg
+
+
+class RecordingContainer:
+    def __init__(self, *, fail_apply: bool = False) -> None:
+        self.config_store = RecordingConfigStore()
+        self.fail_apply = fail_apply
+        self.events: list[str] = []
+
+    def prepare_config_for_storage(self, cfg: AppConfig) -> AppConfig:
+        self.events.append("prepare")
+        return cfg
+
+    def apply_config(self, _cfg: AppConfig) -> None:
+        self.events.append("apply")
+        if self.fail_apply:
+            raise ProviderError("Ollama Cloud requires an API key")
+
+
+def test_update_config_does_not_persist_when_apply_fails() -> None:
+    container = RecordingContainer(fail_apply=True)
+    cfg = AppConfig(
+        deployment_profile=DeploymentProfile.CLOUD_ACCELERATED,
+        provider=ProviderConfig(
+            name="Ollama Cloud",
+            base_url="https://ollama.com",
+            planner_model="llama3",
+            generator_model="llama3",
+            gatherer_model="llama3",
+            api_key="",
+        )
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        update_config(cfg, container=container)
+
+    assert exc_info.value.status_code == 400
+    assert "Ollama Cloud requires an API key" in str(exc_info.value.detail)
+    assert container.config_store.writes == []
+    assert container.events == ["prepare", "apply"]
+
+
+def test_update_config_persists_after_successful_apply() -> None:
+    container = RecordingContainer()
+    cfg = AppConfig()
+
+    stored = update_config(cfg, container=container)
+
+    assert stored == cfg
+    assert container.config_store.writes == [cfg]
+    assert container.events == ["prepare", "apply"]


### PR DESCRIPTION
### Motivation
- Prevent persisting an invalid provider configuration (e.g., selecting Ollama Cloud without an API key) which can cause Provider construction to raise and permanently break startup or config application.
- Close a persistence race where the router wrote `config.json` before calling `apply_config()`, leaving a bad config on disk if `apply_config()` fails.

### Description
- Reordered the config update flow in `api/app/routers/config.py` to call `container.apply_config(sanitized)` before `container.config_store.write(sanitized)` so validation/provider construction runs before persisting the config.
- Continued to use `container.prepare_config_for_storage(cfg)` to redact/store secrets via the existing vault flow and then apply the sanitized config; only write to disk after successful apply.
- Added regression tests in `api/tests/api/test_config_router.py` that assert a failed `apply_config()` does not call `config_store.write()` and that a successful `apply_config()` still persists the config.

### Testing
- Ran the new router tests with `cd api && uv run pytest tests/api/test_config_router.py`, and both tests passed (`2 passed`).
- Ran linting with `cd api && uv run ruff check app/routers/config.py tests/api/test_config_router.py`, which passed with no issues.
- Performed a `git diff --check` to ensure no whitespace/patch issues, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18839cd6e483278672361756a02b1a)