### PR TITLE
Fix protected route scope enforcement

### DIFF
--- a/api/app/core/security_middleware.py
+++ b/api/app/core/security_middleware.py
@@ -53,18 +53,23 @@ ROUTE_SCOPES = {
     "/api/artifacts/build": "admin",
     "/api/cache/clear": "admin",
     "/api/cache/rebuild": "admin",
+    "/api/metrics/presets/clear": "admin",
+    "/monitoring/cache/clear": "admin",
     "/rag/audit": "admin",
     "/query": "read",
     "/documents": "write",
     "/config": "admin",
     "/evaluation": "read",
+    "/experiments": "write",
     "/providers": "read",
     "/security": "read",
     "/install": "read",
+    "/onboarding": "read",
     "/monitoring": "read",
     "/api/traces": "read",
     "/api/artifacts": "read",
     "/api/cache": "read",
+    "/api/metrics": "read",
     "/admin": "admin",
     "/api/keys": "admin",
 }
@@ -106,7 +111,7 @@ def _resolve_required_scope(path: str, method: str) -> str | None:
     """Resolve required scope based on request path and method."""
     if path.startswith("/documents"):
         return "read" if method.upper() in {"GET", "HEAD", "OPTIONS"} else "write"
-    for prefix, scope in ROUTE_SCOPES.items():
+    for prefix, scope in sorted(ROUTE_SCOPES.items(), key=lambda item: len(item[0]), reverse=True):
         if path.startswith(prefix):
             return scope
     return None
@@ -187,6 +192,18 @@ async def verify_api_key(
         )
 
     required_scope = _resolve_required_scope(path, request.method)
+
+    if required_scope is None:
+        audit_log = get_audit_log()
+        audit_log.log_auth(
+            success=False,
+            ip_address=request.client.host if request.client else None,
+            reason=f"No scope mapping for protected route: {path}",
+        )
+        raise HTTPException(
+            status_code=403,
+            detail="Protected route is not configured with an authorization scope.",
+        )
 
     if not auth.verify(api_key, required_scope=required_scope):
         audit_log = get_audit_log()

--- a/api/tests/core/test_security_middleware.py
+++ b/api/tests/core/test_security_middleware.py
@@ -1,0 +1,78 @@
+"""Tests for route-to-scope authorization decisions."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from app.core import security_middleware
+from app.core.auth import APIKeyAuth
+from app.core.security_middleware import _resolve_required_scope, verify_api_key
+
+
+@pytest.mark.parametrize(
+    ("path", "method", "scope"),
+    [
+        ("/monitoring/traces", "GET", "read"),
+        ("/api/traces/last", "GET", "read"),
+        ("/api/artifacts/graph", "GET", "read"),
+        ("/api/cache/status", "GET", "read"),
+        ("/api/metrics/presets/estimates", "GET", "read"),
+        ("/providers/local", "GET", "read"),
+        ("/api/artifacts/build", "POST", "admin"),
+        ("/api/cache/clear", "DELETE", "admin"),
+        ("/api/cache/rebuild", "POST", "admin"),
+        ("/api/metrics/presets/clear", "DELETE", "admin"),
+        ("/monitoring/cache/clear", "POST", "admin"),
+    ],
+)
+def test_sensitive_protected_routes_resolve_expected_scopes(path: str, method: str, scope: str) -> None:
+    assert _resolve_required_scope(path, method) == scope
+
+
+def test_more_specific_scope_mapping_wins_for_mutating_routes() -> None:
+    read_key_auth = APIKeyAuth(enabled=True)
+    read_key, _ = read_key_auth.generate_key("reader", scopes=["read"])
+
+    assert not read_key_auth.verify(
+        read_key,
+        required_scope=_resolve_required_scope("/monitoring/cache/clear", "POST"),
+    )
+    assert not read_key_auth.verify(
+        read_key,
+        required_scope=_resolve_required_scope("/api/metrics/presets/clear", "DELETE"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_verify_api_key_fails_closed_for_unmapped_protected_route(monkeypatch) -> None:
+    auth = APIKeyAuth(enabled=True)
+    api_key, _ = auth.generate_key("reader", scopes=["read"])
+
+    class URL:
+        path = "/unmapped/protected"
+
+    class State:
+        pass
+
+    class Client:
+        host = "127.0.0.1"
+
+    class Request:
+        url = URL()
+        method = "GET"
+        state = State()
+        client = Client()
+
+    class AuditLog:
+        def log_auth(self, **kwargs) -> None:
+            pass
+
+    monkeypatch.setattr(security_middleware, "get_auth", lambda: auth)
+    monkeypatch.setattr(security_middleware, "get_audit_log", lambda: AuditLog())
+
+    with pytest.raises(HTTPException) as exc_info:
+        await verify_api_key(Request(), api_key=api_key)
+
+    assert exc_info.value.status_code == 403
+    assert "not configured" in exc_info.value.detail


### PR DESCRIPTION
### Motivation
- Close an authorization gap where protected routers without an explicit scope mapping were treated as authentication-only, allowing low-privilege keys to access sensitive read or mutating endpoints.
- Ensure that more specific route prefixes (e.g. mutating child routes) take precedence over broader prefixes so admin/write mappings cannot be bypassed by a parent read mapping.

### Description
- Expanded `ROUTE_SCOPES` in `api/app/core/security_middleware.py` to include missing sensitive prefixes such as `/api/metrics`, `/api/metrics/presets/clear`, `/monitoring/cache/clear`, `/experiments`, and `/onboarding` so these routes receive explicit scope requirements.
- Updated scope resolution to match the longest route prefix first by iterating `ROUTE_SCOPES` sorted by key length, so specific admin/write routes override broader read mappings (`_resolve_required_scope`).
- Changed `verify_api_key` to fail closed by rejecting requests with a 403 when `_resolve_required_scope` returns `None` for a protected route, preventing authentication-only access to unmapped protected paths.
- Added focused tests at `api/tests/core/test_security_middleware.py` that verify scope resolution for sensitive routes, that mutating admin routes deny read-only keys, and that unmapped protected routes are rejected.

### Testing
- Ran the new unit tests with `cd api && .venv/bin/python -m pytest tests/core/test_security_middleware.py`, and all tests passed (`13 passed`).
- Ran lint checks with `cd api && .venv/bin/ruff check app/core/security_middleware.py tests/core/test_security_middleware.py`, and the file passed ruff checks.
- Also ran a broader test run `cd api && .venv/bin/python -m pytest tests/api/test_endpoints.py tests/core/test_security_middleware.py`; the new security tests passed but one unrelated pre-existing endpoint test (`test_document_ingest_query_and_evaluation`) failed in that run due to missing evidence chunks in the query response and is not caused by these authorization changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1884bd94848327ba572920df51fc86)