### PR TITLE
Scope full-query cache by request context

### DIFF
--- a/api/app/core/orchestrator.py
+++ b/api/app/core/orchestrator.py
@@ -596,6 +596,32 @@ class Orchestrator:
             status=status,
         )
 
+    def _query_cache_scope(
+        self,
+        document_ids: list[str] | None = None,
+        history: list[dict[str, str]] | None = None,
+        conversation_id: str | None = None,
+        cache_scope: str | None = None,
+    ) -> str | None:
+        """Create a request-scope fingerprint for full-answer cache entries.
+
+        Full query results include generated text and source snippets, so the cache
+        must vary on request-local inputs that can change authorization or model
+        context.  Routers may pass an already-hashed user/ACL scope in
+        ``cache_scope``; direct callers are still protected by folding document
+        filters, chat history, and memory conversation IDs into this fingerprint.
+        """
+        scope_payload = {
+            "cache_scope": cache_scope or "",
+            "document_ids": sorted(document_ids or []),
+            "history": history or [],
+            "conversation_id": conversation_id or "",
+        }
+        if not any(scope_payload.values()):
+            return None
+        encoded = json.dumps(scope_payload, sort_keys=True, default=str)
+        return hashlib.sha256(encoded.encode()).hexdigest()[:16]
+
     def _cache_config_hash(
         self,
         document_ids: list[str] | None,
@@ -766,7 +792,13 @@ class Orchestrator:
             return list(seen.values())
 
         cache_manager = get_cache_manager()
-        cache_hash = self._cache_config_hash(document_ids, cache_scope)
+        query_cache_scope = self._query_cache_scope(
+            document_ids=document_ids,
+            history=history,
+            conversation_id=conversation_id,
+            cache_scope=cache_scope,
+        )
+        cache_hash = self._cache_config_hash(document_ids, query_cache_scope)
 
         # G3: Get corpus version and retrieval mode for versioned cache keys
         cache_corpus_version = ""
@@ -810,7 +842,7 @@ class Orchestrator:
             retrieval_mode=int(cache_retrieval_mode),
             preset_id=current_preset_id,
             model_ids=model_ids,
-            scope_key=cache_scope,
+            scope_key=query_cache_scope,
         )
         cache_event = disk_cache.get_last_event()
 
@@ -2435,7 +2467,7 @@ The retrieved evidence contains some conflicting information. When you encounter
             retrieval_mode=int(retrieval_mode_flags),
             preset_id=current_preset_id,
             model_ids=model_ids,
-            scope_key=cache_scope,
+            scope_key=query_cache_scope,
         )
 
         return result

--- a/api/app/core/persistence.py
+++ b/api/app/core/persistence.py
@@ -300,7 +300,7 @@ class DiskQueryCache:
     """SQLite-backed query result cache with versioned keys.
 
     Implements P0.3: Cache keys include corpus version, retrieval mode,
-    preset ID, model IDs, and normalized query.
+    preset ID, model IDs, request scope, and normalized query.
 
     Cache persists across sessions to disk.
     """

--- a/api/tests/test_query_cache_security.py
+++ b/api/tests/test_query_cache_security.py
@@ -1,0 +1,65 @@
+"""Security regression tests for full-query cache scoping."""
+
+from __future__ import annotations
+
+from app.core.orchestrator import Orchestrator
+from app.core.persistence import DiskQueryCache, QueryCacheConfig
+
+
+def test_disk_query_cache_varies_by_scope_key(tmp_path):
+    """Same normalized query must not hit across different request scopes."""
+    cache = DiskQueryCache(QueryCacheConfig(db_path=tmp_path / "query_cache.db"))
+    try:
+        cache.set(
+            " What is the launch code? ",
+            {"answer": "secret", "chunks": [{"id": "secret-doc:1"}]},
+            corpus_version="v1",
+            retrieval_mode=1,
+            preset_id="balanced",
+            model_ids={"generator": "test-model"},
+            scope_key="secret-doc-scope",
+        )
+
+        assert cache.get(
+            "what IS the launch code?",
+            corpus_version="v1",
+            retrieval_mode=1,
+            preset_id="balanced",
+            model_ids={"generator": "test-model"},
+            scope_key="public-doc-scope",
+        ) is None
+        assert cache.get(
+            "what IS the launch code?",
+            corpus_version="v1",
+            retrieval_mode=1,
+            preset_id="balanced",
+            model_ids={"generator": "test-model"},
+            scope_key="secret-doc-scope",
+        )["answer"] == "secret"
+    finally:
+        cache.close()
+
+
+def test_orchestrator_cache_scope_includes_request_context():
+    """Document filters and private chat history must change full-query cache scope."""
+    orchestrator = Orchestrator.__new__(Orchestrator)
+
+    base_scope = orchestrator._query_cache_scope(document_ids=["doc-a"], cache_scope="user-a")
+    same_scope = orchestrator._query_cache_scope(document_ids=["doc-a"], cache_scope="user-a")
+    other_doc_scope = orchestrator._query_cache_scope(document_ids=["doc-b"], cache_scope="user-a")
+    history_scope = orchestrator._query_cache_scope(
+        document_ids=["doc-a"],
+        history=[{"role": "user", "content": "Private project is Orchid"}],
+        cache_scope="user-a",
+    )
+    other_history_scope = orchestrator._query_cache_scope(
+        document_ids=["doc-a"],
+        history=[{"role": "user", "content": "Private project is Juniper"}],
+        cache_scope="user-a",
+    )
+
+    assert base_scope == same_scope
+    assert base_scope != other_doc_scope
+    assert base_scope != history_scope
+    assert history_scope != other_history_scope
+    assert orchestrator._query_cache_scope() is None


### PR DESCRIPTION
### Motivation
- The disk-backed full-query cache previously omitted request-local inputs (document filters, chat history, conversation/user scope) from its key, allowing cached answers and retrieved snippets to be returned across different authorization/visibility contexts.
- Full answers include generated text and source snippets, so cached results must be partitioned by request scope to avoid cross-request data disclosure.

### Description
- Added `Orchestrator._query_cache_scope(...)` to produce a short fingerprint that folds router-provided `cache_scope`, `document_ids`, `history`, and `conversation_id` into a request-scoped cache fingerprint.
- Wired the derived `query_cache_scope` into both the in-memory cache config hash path (`_cache_config_hash`) and the disk-backed cache calls so `DiskQueryCache.get` / `DiskQueryCache.set` receive `scope_key=query_cache_scope`.
- Updated the disk cache documentation to state that request scope is part of the versioned cache key in `api/app/core/persistence.py`.
- Added security regression tests `api/tests/test_query_cache_security.py` that assert cache misses across different scope keys and that document filters/history change the orchestrator cache scope.

### Testing
- Ran the new unit tests with `cd api && .venv/bin/python -m pytest tests/test_query_cache_security.py`, and both tests passed (`2 passed`).
- Ran static checks with `cd api && .venv/bin/python -m ruff check app/core/orchestrator.py app/core/persistence.py tests/test_query_cache_security.py`, and lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a188647edbc832788ce7f822e42bf65)