### PR TITLE
Restrict managed model downloads to configured models

### DIFF
--- a/api/app/routers/config.py
+++ b/api/app/routers/config.py
@@ -60,6 +60,29 @@ def _delete_model_cache(model_id: str) -> None:
         raise HTTPException(status_code=500, detail=f"Delete failed: {exc}") from exc
 
 
+def _resolve_managed_model(payload: ModelDownloadRequest, container: ServiceContainer) -> str:
+    kind = payload.kind.lower().strip()
+    if kind not in {"embedding", "reranker"}:
+        raise HTTPException(status_code=400, detail="kind must be 'embedding' or 'reranker'")
+
+    model = payload.model.strip()
+    if not model:
+        raise HTTPException(status_code=400, detail="model is required")
+
+    cfg = container.config_store.read()
+    expected_model = (
+        cfg.retrieval.embedding_model
+        if kind == "embedding"
+        else cfg.retrieval.reranker_model
+    )
+    if model != expected_model:
+        raise HTTPException(
+            status_code=403,
+            detail=f"{kind} model management is limited to the configured model",
+        )
+    return model
+
+
 @router.get("", response_model=AppConfig)
 def read_config(container: ServiceContainer = Depends(get_container)):
     return container.config_store.read()
@@ -228,25 +251,23 @@ def quality_recommendations(
 
 
 @router.post("/models/download")
-def download_model(payload: ModelDownloadRequest):
-    kind = payload.kind.lower().strip()
-    if kind not in {"embedding", "reranker"}:
-        raise HTTPException(status_code=400, detail="kind must be 'embedding' or 'reranker'")
-    if not payload.model:
-        raise HTTPException(status_code=400, detail="model is required")
-    _download_model(payload.model)
-    return {"status": "ok", "model": payload.model}
+def download_model(
+    payload: ModelDownloadRequest,
+    container: ServiceContainer = Depends(get_container),
+):
+    model = _resolve_managed_model(payload, container)
+    _download_model(model)
+    return {"status": "ok", "model": model}
 
 
 @router.post("/models/delete")
-def delete_model(payload: ModelDownloadRequest):
-    kind = payload.kind.lower().strip()
-    if kind not in {"embedding", "reranker"}:
-        raise HTTPException(status_code=400, detail="kind must be 'embedding' or 'reranker'")
-    if not payload.model:
-        raise HTTPException(status_code=400, detail="model is required")
-    _delete_model_cache(payload.model)
-    return {"status": "ok", "model": payload.model}
+def delete_model(
+    payload: ModelDownloadRequest,
+    container: ServiceContainer = Depends(get_container),
+):
+    model = _resolve_managed_model(payload, container)
+    _delete_model_cache(model)
+    return {"status": "ok", "model": model}
 
 
 @router.get("/presets", response_model=dict[str, RetrievalDefaults])

--- a/api/tests/api/test_endpoints.py
+++ b/api/tests/api/test_endpoints.py
@@ -11,6 +11,7 @@ from fastapi.testclient import TestClient
 
 from app.core.golden_eval import AnswerMetrics, EvalRunResult, EvalRunStore, GoldenSetStore, RetrievalMetrics
 from app.main import app
+from app.routers import config as config_router
 from app.routers import evaluation
 from app.core.security_middleware import _resolve_route_timeout
 from app.schemas.query import QueryResponse
@@ -48,6 +49,40 @@ def test_config_roundtrip(client: TestClient) -> None:
     update = client.put("/config", json=config)
     assert update.status_code == 200
     assert update.json()["profile"] == "Smoke"
+
+
+def test_model_download_rejects_unconfigured_model(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    downloaded: list[str] = []
+    monkeypatch.setattr(config_router, "_download_model", downloaded.append)
+
+    resp = client.post(
+        "/config/models/download",
+        json={"kind": "embedding", "model": "bigscience/bloom"},
+    )
+
+    assert resp.status_code == 403
+    assert downloaded == []
+    assert "configured model" in resp.json()["detail"]
+
+
+def test_model_download_allows_configured_model(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    downloaded: list[str] = []
+    monkeypatch.setattr(config_router, "_download_model", downloaded.append)
+
+    resp = client.post(
+        "/config/models/download",
+        json={"kind": "embedding", "model": "BAAI/bge-base-en-v1.5"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok", "model": "BAAI/bge-base-en-v1.5"}
+    assert downloaded == ["BAAI/bge-base-en-v1.5"]
 
 
 def test_config_rejects_cloud_provider_in_local_only_mode(client: TestClient) -> None:


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated clients from requesting arbitrary Hugging Face repos which can exhaust disk/network/CPU by limiting server-side model downloads to the configured models.
- Address a DoS/resource-consumption risk introduced by the unrestricted `/config/models/download` and `/config/models/delete` handlers.

### Description
- Add `_resolve_managed_model(payload: ModelDownloadRequest, container: ServiceContainer)` in `api/app/routers/config.py` to validate `kind` and ensure the requested `model` matches the service's configured embedding or reranker model.
- Update `download_model` and `delete_model` to accept `container: ServiceContainer = Depends(get_container)` and use `_resolve_managed_model(...)` before calling the existing `_download_model` or `_delete_model_cache` helpers, preventing arbitrary repo IDs from reaching `huggingface_hub.snapshot_download`.
- Keep low-level helpers `_download_model` and `_delete_model_cache` unchanged so internal behaviour remains the same for allowed models.
- Add regression tests in `api/tests/api/test_endpoints.py` that mock `_download_model` to assert that an unconfigured model is rejected with `403` and that the configured model is allowed and triggers the download helper.

### Testing
- Ran targeted tests: `cd api && uv run pytest tests/api/test_endpoints.py::test_model_download_rejects_unconfigured_model tests/api/test_endpoints.py::test_model_download_allows_configured_model -q`, and both tests passed.
- Compiled modules: `cd api && uv run python -m compileall app tests/api/test_endpoints.py` completed successfully.
- Ran the full `tests/api/test_endpoints.py` via `cd api && uv run pytest tests/api/test_endpoints.py -q` which exposed one pre-existing integration failure unrelated to this change (dense retrieval disabled due to missing `sentence-transformers` causing no evidence chunks); the new targeted tests still pass in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18859d840c8327b53d73eaabd44f51)