### PR TITLE
Enforce onboarding API key scopes

### DIFF
--- a/api/app/core/security_middleware.py
+++ b/api/app/core/security_middleware.py
@@ -104,8 +104,12 @@ def is_exposed_mode() -> bool:
 
 def _resolve_required_scope(path: str, method: str) -> str | None:
     """Resolve required scope based on request path and method."""
+    read_methods = {"GET", "HEAD", "OPTIONS"}
+    method = method.upper()
     if path.startswith("/documents"):
-        return "read" if method.upper() in {"GET", "HEAD", "OPTIONS"} else "write"
+        return "read" if method in read_methods else "write"
+    if path.startswith("/onboarding"):
+        return "read" if method in read_methods else "write"
     for prefix, scope in ROUTE_SCOPES.items():
         if path.startswith(prefix):
             return scope

--- a/api/tests/api/test_endpoints.py
+++ b/api/tests/api/test_endpoints.py
@@ -9,10 +9,12 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
+from app.core import auth as auth_module
+from app.core.auth import APIKeyAuth
 from app.core.golden_eval import AnswerMetrics, EvalRunResult, EvalRunStore, GoldenSetStore, RetrievalMetrics
 from app.main import app
 from app.routers import evaluation
-from app.core.security_middleware import _resolve_route_timeout
+from app.core.security_middleware import _resolve_required_scope, _resolve_route_timeout
 from app.schemas.query import QueryResponse
 from app.services import ServiceContainer, get_container
 from app.state import get_orchestrator, set_orchestrator
@@ -378,6 +380,41 @@ def test_document_ingest_query_and_evaluation(client: TestClient) -> None:
     eval_data = eval_resp.json()
     assert eval_data["responses"], "evaluation should include responses"
     assert eval_data["average_coverage"] >= 0
+
+
+def test_onboarding_scope_resolution_is_method_specific() -> None:
+    assert _resolve_required_scope("/onboarding", "GET") == "read"
+    assert _resolve_required_scope("/onboarding/demo/seed", "POST") == "write"
+    assert _resolve_required_scope("/onboarding/demo", "DELETE") == "write"
+
+
+def test_onboarding_demo_mutations_require_write_scope(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    auth = APIKeyAuth(enabled=True)
+    read_key, _ = auth.generate_key("read-only", scopes=["read"])
+    write_key, _ = auth.generate_key("writer", scopes=["write"])
+    monkeypatch.setattr(auth_module, "_auth_instance", auth)
+
+    read_headers = {"X-API-Key": read_key}
+    write_headers = {"X-API-Key": write_key}
+
+    onboarding = client.get("/onboarding", headers=read_headers)
+    assert onboarding.status_code == 200
+
+    seed_denied = client.post("/onboarding/demo/seed", headers=read_headers)
+    assert seed_denied.status_code == 403
+
+    seed_allowed = client.post("/onboarding/demo/seed", headers=write_headers)
+    assert seed_allowed.status_code == 200
+    assert seed_allowed.json()["seeded"]
+
+    clear_denied = client.delete("/onboarding/demo", headers=read_headers)
+    assert clear_denied.status_code == 403
+
+    clear_allowed = client.delete("/onboarding/demo", headers=write_headers)
+    assert clear_allowed.status_code == 200
+    assert clear_allowed.json()["deleted"] > 0
 
 
 def test_onboarding_demo_seed_query_and_clear(client: TestClient) -> None:


### PR DESCRIPTION
### Motivation
- Onboarding endpoints (`/onboarding/*`) were not covered by the route-prefix scope table, which resulted in `required_scope` resolving to `None` and allowing any valid API key (including read-only keys) to perform mutating operations like seeding or clearing the demo corpus.

### Description
- Make `_resolve_required_scope()` method-aware for the `/onboarding` prefix so `GET`/`HEAD`/`OPTIONS` return `read` and mutating methods return `write` in `api/app/core/security_middleware.py`.
- Add regression tests in `api/tests/api/test_endpoints.py` that assert method-specific scope resolution and that read-only keys can read onboarding metadata but are denied `POST /onboarding/demo/seed` and `DELETE /onboarding/demo` while write-scoped keys are allowed.
- Keep existing onboarding handlers unchanged and rely on the centralized scope resolution to enforce API key permissions.

### Testing
- Ran the targeted tests: `PYTHONPATH=api api/.venv/bin/python -m pytest api/tests/api/test_endpoints.py -k 'onboarding_scope or onboarding_demo_mutations'`, and both new tests passed.
- Ran static formatting/checks with `cd api && .venv/bin/ruff check app/core/security_middleware.py tests/api/test_endpoints.py` and applied formatting; checks passed after formatting.
- Executed the full endpoint test file with `PYTHONPATH=api api/.venv/bin/python -m pytest api/tests/api/test_endpoints.py`; the suite reports one unrelated, pre-existing failure in `test_document_ingest_query_and_evaluation` due to environment-dependent dense retrieval being unavailable (`sentence-transformers not installed`), while all other tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1896e551788327843ee556d4b0d193)