### PR TITLE
Restrict sensitive report metadata and require admin scope for sensitive report endpoints

### DIFF
--- a/api/app/core/golden_eval.py
+++ b/api/app/core/golden_eval.py
@@ -299,27 +299,48 @@ class EvalRunStore:
         except json.JSONDecodeError:
             return None
 
-    def list_runs(self, limit: int = 50) -> list[dict[str, Any]]:
-        """List recent runs (summary only)."""
+    def list_runs(self, limit: int = 50, *, include_sensitive: bool = False) -> list[dict[str, Any]]:
+        """List recent runs, omitting operator-only audit metadata by default."""
         runs = sorted(
             self._runs.values(),
             key=lambda r: r["timestamp"],
             reverse=True
         )[:limit]
-        return [
-            {
+        summaries = []
+        for r in runs:
+            audit = r.get("audit", {})
+            summary = {
                 "run_id": r["run_id"],
                 "golden_set_name": r["golden_set_name"],
                 "timestamp": r["timestamp"],
                 "retrieval_metrics": r["retrieval_metrics"],
                 "answer_metrics": r["answer_metrics"],
                 "duration_ms": r.get("duration_ms", 0),
-                "report_path": r.get("report_path", ""),
                 "report_sha256": r.get("report_sha256", ""),
-                "audit": r.get("audit", {}),
+                "audit": audit if include_sensitive else self._public_audit_summary(audit),
             }
-            for r in runs
-        ]
+            if include_sensitive:
+                summary["report_path"] = r.get("report_path", "")
+            summaries.append(summary)
+        return summaries
+
+    @staticmethod
+    def _public_audit_summary(audit: dict[str, Any]) -> dict[str, Any]:
+        """Return the audit fields safe for read-scoped summaries."""
+        if not isinstance(audit, dict):
+            return {}
+        golden_set = audit.get("golden_set")
+        safe_golden_set = {}
+        if isinstance(golden_set, dict):
+            for key in ("name", "case_count", "tag_counts", "fingerprint"):
+                if key in golden_set:
+                    safe_golden_set[key] = golden_set[key]
+        safe = {}
+        if audit.get("schema_version"):
+            safe["schema_version"] = audit["schema_version"]
+        if safe_golden_set:
+            safe["golden_set"] = safe_golden_set
+        return safe
 
 
 # ============================================================================

--- a/api/app/core/install_report.py
+++ b/api/app/core/install_report.py
@@ -47,6 +47,29 @@ def _safe_float(value: Any) -> float:
         return 0.0
 
 
+def _summarize_policy(policy: dict[str, Any]) -> dict[str, Any]:
+    """Keep install reports free of backend IDs, URLs, and fallback topology."""
+    guardrails = _safe_mapping(policy.get("guardrails"))
+    backends = _safe_mapping(policy.get("backends"))
+    fallbacks = _safe_mapping(policy.get("fallbacks"))
+    data_policy = _safe_mapping(policy.get("data_policy"))
+    return {
+        "guardrails": guardrails,
+        "data_policy": {
+            key: data_policy[key]
+            for key in (
+                "external_model_calls_allowed",
+                "managed_cloud_hosting_allowed",
+                "pii_redaction_required",
+                "report_export_mode",
+            )
+            if key in data_policy
+        },
+        "backend_count": len(backends),
+        "fallback_count": len(fallbacks),
+    }
+
+
 def _client_readiness_state(evaluations: list[dict[str, Any]]) -> dict[str, Any]:
     client_eval = next(
         (item for item in evaluations if item.get("golden_set_name") == CLIENT_READINESS_SET),
@@ -274,7 +297,7 @@ def build_install_report(
 ) -> InstallReportResponse:
     """Build a single redacted report for client install evidence."""
     corpus = _collect_corpus(container)
-    policy = container.local_first.describe()
+    policy = _summarize_policy(container.local_first.describe())
     evidence = _build_evidence(corpus, evaluations, artifacts)
     actions = _build_actions(readiness, security, corpus, evaluations)
 
@@ -303,6 +326,6 @@ def build_install_report(
         actions=actions,
         redaction={
             "secrets": "API keys, tokens, passwords, credentials, and secret-shaped config keys are omitted or redacted.",
-            "scope": "Report includes operational metadata only; ingested document text and retrieved chunks are not embedded.",
+            "scope": "Report excludes backend definitions, fallback topology, local artifact paths, and operator audit snapshots.",
         },
     )

--- a/api/app/core/security_middleware.py
+++ b/api/app/core/security_middleware.py
@@ -106,7 +106,11 @@ def _resolve_required_scope(path: str, method: str) -> str | None:
     """Resolve required scope based on request path and method."""
     if path.startswith("/documents"):
         return "read" if method.upper() in {"GET", "HEAD", "OPTIONS"} else "write"
-    for prefix, scope in ROUTE_SCOPES.items():
+    if path == "/install/report":
+        return "admin"
+    if path.startswith("/evaluation/runs/") and path.endswith("/report"):
+        return "admin"
+    for prefix, scope in sorted(ROUTE_SCOPES.items(), key=lambda item: len(item[0]), reverse=True):
         if path.startswith(prefix):
             return scope
     return None

--- a/api/tests/api/test_endpoints.py
+++ b/api/tests/api/test_endpoints.py
@@ -12,7 +12,7 @@ from fastapi.testclient import TestClient
 from app.core.golden_eval import AnswerMetrics, EvalRunResult, EvalRunStore, GoldenSetStore, RetrievalMetrics
 from app.main import app
 from app.routers import evaluation
-from app.core.security_middleware import _resolve_route_timeout
+from app.core.security_middleware import _resolve_required_scope, _resolve_route_timeout
 from app.schemas.query import QueryResponse
 from app.services import ServiceContainer, get_container
 from app.state import get_orchestrator, set_orchestrator
@@ -38,6 +38,12 @@ def client():
         evaluation._golden_store = previous_golden_store
         evaluation._eval_run_store = previous_eval_run_store
         evaluation._evaluator = previous_evaluator
+
+
+def test_sensitive_report_routes_require_admin_scope() -> None:
+    assert _resolve_required_scope("/install/report", "GET") == "admin"
+    assert _resolve_required_scope("/evaluation/runs/run-1/report", "GET") == "admin"
+    assert _resolve_required_scope("/evaluation/runs", "GET") == "read"
 
 
 def test_config_roundtrip(client: TestClient) -> None:
@@ -132,6 +138,9 @@ def test_install_report_collects_redacted_handoff_evidence(client: TestClient) -
     assert body["security"]["settings"]["api_keys_configured"] is False
     assert body["corpus"]["document_count"] == 0
     assert body["redaction"]["secrets"]
+    assert "backends" not in body["policy"]
+    assert "fallbacks" not in body["policy"]
+    assert "backend_count" in body["policy"]
     evidence = {item["id"]: item for item in body["evidence"]}
     assert evidence["security_posture"]["endpoint"] == "/security/posture"
     assert "prompt-injection" in evidence["security_posture"]["detail"]

--- a/api/tests/test_golden_eval_artifacts.py
+++ b/api/tests/test_golden_eval_artifacts.py
@@ -140,8 +140,14 @@ async def test_eval_run_store_lists_report_artifact_metadata(tmp_path: Path) -> 
     run_id = result.run_id
     [summary] = run_store.list_runs()
     assert summary["run_id"] == run_id
-    assert summary["report_path"]
+    assert "report_path" not in summary
     assert summary["report_sha256"]
+    assert "corpus" not in summary["audit"]
+    assert "config_snapshot" not in summary["audit"]
+
+    [sensitive_summary] = run_store.list_runs(include_sensitive=True)
+    assert sensitive_summary["report_path"]
+    assert sensitive_summary["audit"]["corpus"]["fingerprint"] == "corpus-test-fingerprint"
 
 
 def test_eval_config_redaction_catches_secret_shaped_keys() -> None:


### PR DESCRIPTION
### Motivation
- Read-scoped report endpoints were returning operator/admin configuration and audit metadata (backend IDs/URLs, fallback topology, local artifact paths, corpus titles) that should be admin-only, creating a confidentiality leak. 

### Description
- Require `admin` scope for sensitive report routes by updating `_resolve_required_scope` so `/install/report` and `/evaluation/runs/{run_id}/report` require `admin`, while keeping `/evaluation/runs` readable with `read` scope. (`api/app/core/security_middleware.py`)
- Sanitize evaluation run listings by changing `EvalRunStore.list_runs` to omit `report_path` and replace the full `audit` with a public summary by default, and add an `include_sensitive: bool` flag plus `_public_audit_summary` for internal consumers that need full metadata. (`api/app/core/golden_eval.py`)
- Summarize the install policy in the install report via `_summarize_policy` so reports expose only high-level guardrails, selected `data_policy` flags, and counts of backends/fallbacks instead of backend definitions, URLs, model IDs, or fallback topology. (`api/app/core/install_report.py`)
- Add/adjust tests to assert the new admin-only route resolution and the redacted/summarized outputs for install and evaluation summaries. (`api/tests/api/test_endpoints.py`, `api/tests/test_golden_eval_artifacts.py`)

### Testing
- Ran targeted unit/integration tests: `cd api && uv run pytest -q tests/api/test_endpoints.py::test_sensitive_report_routes_require_admin_scope tests/api/test_endpoints.py::test_install_report_collects_redacted_handoff_evidence tests/test_golden_eval_artifacts.py::test_eval_run_store_lists_report_artifact_metadata` — all three tests passed. 
- Verified syntax by compiling key modules: `python -m py_compile app/core/security_middleware.py app/core/golden_eval.py app/core/install_report.py` — success. 
- Ran a broader test run `cd api && uv run pytest -q tests/api/test_endpoints.py tests/test_golden_eval_artifacts.py` which completed but exposed one unrelated environment-dependent failure (`test_document_ingest_query_and_evaluation`) caused by missing `sentence-transformers` in the CI environment rather than by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18951803708327b5cda9ba63b708ae)