### PR TITLE
ci: require release evidence in PR gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,6 @@ jobs:
 
   release-evidence:
     name: Release Evidence
-    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -135,7 +134,7 @@ jobs:
   ci-ok:
     name: CI Passed (PR gated)
     if: always()
-    needs: [api, web, install-smoke, container-manifest, research-architecture, evidence-handoff]
+    needs: [api, web, install-smoke, container-manifest, research-architecture, release-evidence, evidence-handoff]
     runs-on: ubuntu-latest
     steps:
       - run: |


### PR DESCRIPTION
### Motivation
- Restore security checks (container smoke, secret scanning, supply-chain evidence) on pull requests because they were previously moved into a job that only ran for `workflow_dispatch` or `refs/heads/main`, allowing PRs to pass the declared gate without those checks.

### Description
- Removed the `if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'` condition from the `release-evidence` job in `.github/workflows/ci.yml` so it runs on PRs as well.
- Added `release-evidence` to the `needs` list of the `ci-ok` job in `.github/workflows/ci.yml` so the PR aggregate gate requires the release evidence steps to succeed.
- No other job logic or scripts were modified.

### Testing
- Ran a Python workflow check that verifies the `if` filter was removed and `release-evidence` is listed in `ci-ok` needs, which passed.
- Executed `bash scripts/secret-scan.sh`, which returned `secret_scan=pass` and succeeded.
- Ran `git diff --check` to validate formatting, which returned no issues.
- Executed `bash scripts/supply-chain-evidence.sh --output-dir /tmp/jr-supply-chain-check`, which failed locally because the installed `uv` version does not support the requested `cyclonedx1.5` export format (environment limitation, not a workflow regression).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a189514fe9c8327b0f6ad45416cace8)