### PR TITLE
Enforce LangExtract timeout without blocking executor shutdown

### DIFF
--- a/api/app/core/langextract_enricher.py
+++ b/api/app/core/langextract_enricher.py
@@ -339,13 +339,15 @@ class LangExtractEnricher:
         return examples
 
     def _run_with_timeout(self, fn: Any, timeout: int) -> Any:
-        with ThreadPoolExecutor(max_workers=1) as executor:
-            future = executor.submit(fn)
-            try:
-                return future.result(timeout=timeout)
-            except FutureTimeoutError as exc:
-                future.cancel()
-                raise TimeoutError(f"LangExtract timed out after {timeout}s") from exc
+        executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="langextract")
+        future = executor.submit(fn)
+        try:
+            return future.result(timeout=timeout)
+        except FutureTimeoutError as exc:
+            future.cancel()
+            raise TimeoutError(f"LangExtract timed out after {timeout}s") from exc
+        finally:
+            executor.shutdown(wait=False, cancel_futures=True)
 
     def _normalize_attributes(self, attributes: Any) -> dict[str, str]:
         if not isinstance(attributes, dict):

--- a/api/tests/test_langextract_enricher.py
+++ b/api/tests/test_langextract_enricher.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -95,6 +96,22 @@ def test_synthetic_sections_are_deterministic_and_capped() -> None:
     assert rendered.count("- ") == 2
     assert "## LangExtract Entities" in rendered
 
+
+def test_run_with_timeout_returns_without_waiting_for_worker_completion(tmp_path: Path) -> None:
+    enricher = LangExtractEnricher(data_dir=tmp_path)
+
+    def slow_extract() -> None:
+        time.sleep(2)
+
+    started = time.monotonic()
+    try:
+        enricher._run_with_timeout(slow_extract, timeout=1)
+    except TimeoutError as exc:
+        elapsed = time.monotonic() - started
+        assert "LangExtract timed out after 1s" in str(exc)
+        assert elapsed < 1.5
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("expected LangExtract timeout")
 
 def test_ingest_fail_open_when_extraction_fails(tmp_path: Path) -> None:
     store = DocumentStore(path=tmp_path / "docs.db")


### PR DESCRIPTION
### Motivation
- The LangExtract wrapper used a `with ThreadPoolExecutor(...)` context, which calls `shutdown(wait=True)` on exit and can block the request worker if the extraction thread is still running, defeating the configured timeout and risking availability degradation.
- The change aims to ensure the configured `langextract_timeout_sec` bounds the ingestion request and preserves the existing fail-open behavior when enrichment fails or times out.

### Description
- Replace the context-managed executor with an explicit `ThreadPoolExecutor` and call `executor.shutdown(wait=False, cancel_futures=True)` in a `finally` block to avoid waiting for the running worker after a timeout in `_run_with_timeout` in `api/app/core/langextract_enricher.py`.
- Add a regression test `test_run_with_timeout_returns_without_waiting_for_worker_completion` in `api/tests/test_langextract_enricher.py` that simulates a slow extraction function and asserts the timeout path returns promptly.
- Files changed: `api/app/core/langextract_enricher.py` and `api/tests/test_langextract_enricher.py`.

### Testing
- Ran `cd api && uv run pytest tests/test_langextract_enricher.py`, and the langextract unit tests passed (`6 passed`).
- Ran `cd api && uv run ruff check app/core/langextract_enricher.py tests/test_langextract_enricher.py`, and lint checks passed.
- Ran the full test suite `cd api && uv run pytest`, which mostly passed but revealed an existing/unrelated failure in `tests/api/test_endpoints.py::test_document_ingest_query_and_evaluation` (the endpoint test returned no evidence chunks), so the change did not cause new failures in the LangExtract unit tests but the full suite still has one unrelated failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19bdf27a2c8327901dba6bd09c2763)