### PR TITLE
Require dedicated `eval` scope for mutating evaluation routes

### DIFF
--- a/api/app/core/security_middleware.py
+++ b/api/app/core/security_middleware.py
@@ -117,6 +117,8 @@ def _resolve_required_scope(path: str, method: str) -> str | None:
         return "admin"
     if path.startswith("/evaluation/runs/") and path.endswith("/report"):
         return "admin"
+    if path.startswith("/evaluation"):
+        return "read" if method in read_methods else "eval"
     if path.startswith("/onboarding"):
         return "read" if method in read_methods else "write"
     for prefix, scope in sorted(ROUTE_SCOPES.items(), key=lambda item: len(item[0]), reverse=True):

--- a/api/tests/core/test_security_middleware.py
+++ b/api/tests/core/test_security_middleware.py
@@ -30,6 +30,31 @@ def test_sensitive_protected_routes_resolve_expected_scopes(path: str, method: s
     assert _resolve_required_scope(path, method) == scope
 
 
+def test_evaluation_scope_resolution_is_method_specific() -> None:
+    assert _resolve_required_scope("/evaluation/golden-sets", "GET") == "read"
+    assert _resolve_required_scope("/evaluation/runs", "GET") == "read"
+    assert _resolve_required_scope("/evaluation/runs/run-1/report", "GET") == "admin"
+    assert _resolve_required_scope("/evaluation", "POST") == "eval"
+    assert _resolve_required_scope("/evaluation/golden-sets", "POST") == "eval"
+    assert _resolve_required_scope("/evaluation/golden-sets/demo", "DELETE") == "eval"
+    assert _resolve_required_scope("/evaluation/batch/demo", "POST") == "eval"
+
+
+def test_evaluation_mutations_require_eval_or_admin_scope() -> None:
+    auth = APIKeyAuth(enabled=True)
+    read_key, _ = auth.generate_key("reader", scopes=["read"])
+    write_key, _ = auth.generate_key("writer", scopes=["write"])
+    eval_key, _ = auth.generate_key("evaluator", scopes=["eval"])
+    admin_key, _ = auth.generate_key("admin", scopes=["admin"])
+
+    required_scope = _resolve_required_scope("/evaluation/golden-sets", "POST")
+
+    assert not auth.verify(read_key, required_scope=required_scope)
+    assert not auth.verify(write_key, required_scope=required_scope)
+    assert auth.verify(eval_key, required_scope=required_scope)
+    assert auth.verify(admin_key, required_scope=required_scope)
+
+
 def test_more_specific_scope_mapping_wins_for_mutating_routes() -> None:
     read_key_auth = APIKeyAuth(enabled=True)
     read_key, _ = read_key_auth.generate_key("reader", scopes=["read"])


### PR DESCRIPTION
### Motivation
- Fix an authorization regression where `/evaluation` was mapped to the generic `read` scope, allowing low-privileged keys to perform mutating or resource-heavy evaluation operations.

### Description
- Update `_resolve_required_scope()` to treat `/evaluation` method-aware so `GET/HEAD/OPTIONS` remain `read` but non-read methods require the dedicated `eval` scope while keeping report endpoints `admin`.
- Add regression tests that assert the `/evaluation` route resolution is method-specific and that `read`/`write` keys cannot perform evaluation mutations while `eval` and `admin` keys can.

### Testing
- Ran linter: `cd api && uv run ruff check app/core/security_middleware.py tests/core/test_security_middleware.py` which passed.
- Ran unit tests: `cd api && uv run pytest tests/core/test_security_middleware.py` and the test suite passed (15 passed).
- Tests were executed under the project-managed test environment (`uv run pytest`) to ensure FastAPI and project dependencies were available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19c11dc07c8327b9ef0f2ea0b648a6)