### PR TITLE
Fix binary document filter query amplification

### DIFF
--- a/api/app/core/binary_vector_store.py
+++ b/api/app/core/binary_vector_store.py
@@ -322,6 +322,24 @@ class MilvusVectorStore:
         # Sum across bytes to get total Hamming distance
         return bit_counts.sum(axis=1)
 
+
+    def _document_filter_indices(
+        self,
+        document_ids: list[str] | set[str] | None = None,
+        filter_expr: str | None = None,
+    ) -> np.ndarray:
+        """Return chunk indices matching the supported document filter."""
+        if document_ids:
+            allowed_ids = set(document_ids)
+        elif filter_expr and 'doc_id ==' in filter_expr:
+            allowed_ids = {filter_expr.split('==')[1].strip().strip('"\'')}
+        else:
+            return np.arange(len(self._chunks))
+
+        return np.array([
+            i for i, chunk in enumerate(self._chunks) if chunk.doc_id in allowed_ids
+        ])
+
     def search(
         self,
         query_embedding: list[float] | np.ndarray,
@@ -350,23 +368,14 @@ class MilvusVectorStore:
         if self._vectors is None:
             return []
 
-        # Quantize query embedding
+        valid_indices = self._document_filter_indices(filter_expr=filter_expr)
+        if len(valid_indices) == 0:
+            return []
+
+        # Quantize query embedding and compute Hamming distances only for the scoped vectors.
         query_bq = float32_to_binary(query_embedding, self._bq_config)
         query_arr = np.frombuffer(query_bq, dtype=np.uint8)
-
-        # Compute Hamming distances
-        distances = self._hamming_distance_batch(query_arr, self._vectors)
-
-        # Apply filter if specified
-        valid_indices = np.arange(len(self._chunks))
-        if filter_expr and 'doc_id ==' in filter_expr:
-                doc_id = filter_expr.split('==')[1].strip().strip('"\'')
-                valid_indices = np.array([
-                    i for i, c in enumerate(self._chunks) if c.doc_id == doc_id
-                ])
-                if len(valid_indices) == 0:
-                    return []
-                distances = distances[valid_indices]
+        distances = self._hamming_distance_batch(query_arr, self._vectors[valid_indices])
 
         # Get top-k indices
         if len(distances) <= top_k:
@@ -379,7 +388,7 @@ class MilvusVectorStore:
         # Build results
         results = []
         for idx in sorted_indices[:top_k]:
-            chunk_idx = valid_indices[idx] if filter_expr else idx
+            chunk_idx = valid_indices[idx]
             chunk = self._chunks[chunk_idx]
             results.append(MilvusSearchResult(
                 id=chunk.id,
@@ -398,6 +407,7 @@ class MilvusVectorStore:
         query_bq: bytes,
         top_k: int = 5,
         filter_expr: str | None = None,
+        document_ids: list[str] | None = None,
     ) -> list[MilvusSearchResult]:
         """Search using pre-quantized binary query vector."""
         self._ensure_connected()
@@ -411,18 +421,12 @@ class MilvusVectorStore:
         if self._vectors is None:
             return []
 
-        query_arr = np.frombuffer(query_bq, dtype=np.uint8)
-        distances = self._hamming_distance_batch(query_arr, self._vectors)
+        valid_indices = self._document_filter_indices(document_ids, filter_expr)
+        if len(valid_indices) == 0:
+            return []
 
-        valid_indices = np.arange(len(self._chunks))
-        if filter_expr and 'doc_id ==' in filter_expr:
-            doc_id = filter_expr.split('==')[1].strip().strip('"\'')
-            valid_indices = np.array([
-                i for i, c in enumerate(self._chunks) if c.doc_id == doc_id
-            ])
-            if len(valid_indices) == 0:
-                return []
-            distances = distances[valid_indices]
+        query_arr = np.frombuffer(query_bq, dtype=np.uint8)
+        distances = self._hamming_distance_batch(query_arr, self._vectors[valid_indices])
 
         if len(distances) <= top_k:
             sorted_indices = np.argsort(distances)
@@ -432,7 +436,7 @@ class MilvusVectorStore:
 
         results = []
         for idx in sorted_indices[:top_k]:
-            chunk_idx = valid_indices[idx] if filter_expr else idx
+            chunk_idx = valid_indices[idx]
             chunk = self._chunks[chunk_idx]
             results.append(MilvusSearchResult(
                 id=chunk.id,

--- a/api/app/core/bq_hybrid_retrieval.py
+++ b/api/app/core/bq_hybrid_retrieval.py
@@ -457,19 +457,7 @@ class BQHybridRetrievalEngine(HybridRetrievalEngine):
         document_ids: list[str] | None,
     ) -> list[MilvusSearchResult]:
         store = self._ensure_bq_store(self._bq_embedding_dim)
-        if document_ids and len(document_ids) == 1:
-            doc_id = document_ids[0]
-            return store.search_binary(query_bq, top_k=top_k, filter_expr=f'doc_id == "{doc_id}"')
-
-        if document_ids and len(document_ids) > 1:
-            combined: list[MilvusSearchResult] = []
-            for doc_id in document_ids:
-                combined.extend(
-                    store.search_binary(query_bq, top_k=top_k, filter_expr=f'doc_id == "{doc_id}"')
-                )
-            return self._dedupe_by_chunk(combined)[:top_k]
-
-        return store.search_binary(query_bq, top_k=top_k)
+        return store.search_binary(query_bq, top_k=top_k, document_ids=document_ids)
 
     def _dedupe_by_chunk(self, results: list[MilvusSearchResult]) -> list[MilvusSearchResult]:
         by_id: dict[str, MilvusSearchResult] = {}

--- a/api/app/schemas/query.py
+++ b/api/app/schemas/query.py
@@ -8,11 +8,16 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 MAX_QUESTION_LENGTH = 10000
+MAX_DOCUMENT_IDS = 100
 
 
 class QueryRequest(BaseModel):
     question: str = Field(..., max_length=MAX_QUESTION_LENGTH, description="The question to answer")
-    document_ids: list[str] | None = None
+    document_ids: list[str] | None = Field(
+        default=None,
+        max_length=MAX_DOCUMENT_IDS,
+        description="Optional document scope for retrieval.",
+    )
     history: list[dict[str, str]] | None = None
     conversation_id: str | None = None
     query_mode: Literal["grounded", "open_domain"] | None = None

--- a/api/tests/test_bq_retrieval.py
+++ b/api/tests/test_bq_retrieval.py
@@ -297,3 +297,16 @@ class TestGetBQRetrievalService:
         config = BQRetrievalConfig(top_k=15)
         service = get_bq_retrieval_service(config=config)
         assert service._config.top_k == 15
+
+
+class TestQueryRequestDocumentIds:
+    def test_document_ids_have_max_length(self):
+        from pydantic import ValidationError
+
+        from app.schemas.query import MAX_DOCUMENT_IDS, QueryRequest
+
+        with pytest.raises(ValidationError):
+            QueryRequest(
+                question="What changed?",
+                document_ids=[str(i) for i in range(MAX_DOCUMENT_IDS + 1)],
+            )

--- a/api/tests/test_milvus_store.py
+++ b/api/tests/test_milvus_store.py
@@ -268,6 +268,51 @@ class TestBinaryVectorStoreSearch:
         assert len(results) == 1
         assert results[0].doc_id == "doc2"
 
+
+    def test_search_binary_filters_before_distance_for_missing_doc(self, monkeypatch):
+        store = MilvusVectorStore(embedding_dim=8)
+        store.connect()
+        store.create_collection()
+        store.insert([
+            MilvusChunk(doc_id="doc1", chunk_id="c1", source="", text="", embedding=[1.0] * 8),
+        ])
+        store.build_index()
+
+        def fail_if_called(*args, **kwargs):
+            raise AssertionError("distance calculation should be skipped when no documents match")
+
+        monkeypatch.setattr(store, "_hamming_distance_batch", fail_if_called)
+
+        results = store.search_binary(b"\xff", top_k=5, document_ids=["missing"])
+
+        assert results == []
+
+    def test_search_binary_scans_matching_documents_once(self, monkeypatch):
+        store = MilvusVectorStore(embedding_dim=8)
+        store.connect()
+        store.create_collection()
+        store.insert([
+            MilvusChunk(doc_id="doc1", chunk_id="c1", source="", text="", embedding=[1.0] * 8),
+            MilvusChunk(doc_id="doc2", chunk_id="c2", source="", text="", embedding=[-1.0] * 8),
+            MilvusChunk(doc_id="doc3", chunk_id="c3", source="", text="", embedding=[1.0] * 8),
+        ])
+        store.build_index()
+
+        calls = []
+        original = store._hamming_distance_batch
+
+        def count_call(query, vectors):
+            calls.append(vectors.shape[0])
+            return original(query, vectors)
+
+        monkeypatch.setattr(store, "_hamming_distance_batch", count_call)
+
+        results = store.search_binary(b"\xff", top_k=5, document_ids=["doc1", "doc2", "missing"])
+
+        assert len(results) == 2
+        assert {result.doc_id for result in results} == {"doc1", "doc2"}
+        assert calls == [2]
+
     def test_delete_by_doc_id(self):
         store = MilvusVectorStore(embedding_dim=8)
         store.connect()


### PR DESCRIPTION
### Motivation
- Prevent CPU amplification when binary retrieval is enabled by avoiding repeated full Hamming scans for every caller-supplied `document_id` and bound the caller-controlled list length.

### Description
- Add `MAX_DOCUMENT_IDS = 100` and constrain `QueryRequest.document_ids` with a Pydantic `Field(max_length=MAX_DOCUMENT_IDS)` in `api/app/schemas/query.py` to limit request-supplied IDs.
- Replace per-`doc_id` looping in `BQHybridRetrievalEngine._search_binary` with a single call that forwards `document_ids` to the vector store in `api/app/core/bq_hybrid_retrieval.py` so searches are not repeated.
- Implement `_document_filter_indices` in `api/app/core/binary_vector_store.py` and apply document filtering before distance computation so `search`/`search_binary` compute Hamming distances only over the scoped vectors, and accept a `document_ids` argument for `search_binary`.
- Add regression tests: two binary-store tests in `api/tests/test_milvus_store.py` to verify missing-doc short-circuits and that matching documents are scanned once, and a schema validation test in `api/tests/test_bq_retrieval.py` for `MAX_DOCUMENT_IDS`.

### Testing
- Ran project test runner: `uv run pytest tests/test_milvus_store.py tests/test_bq_retrieval.py`, all tests passed (`47 passed`).
- Ran linter: `uv run ruff check app/core/binary_vector_store.py app/core/bq_hybrid_retrieval.py app/schemas/query.py tests/test_milvus_store.py tests/test_bq_retrieval.py`, checks passed.
- Note: running `python -m pytest tests/...` in the system Python environment failed during collection due to missing `numpy` (environment dependency), not a code regression; tests pass under the repository `uv` test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19c29af2e48327aa5fe72666a1d86b)