### PR TITLE
fix: avoid logging sensitive pipeline step details

### DIFF
--- a/api/app/core/orchestrator.py
+++ b/api/app/core/orchestrator.py
@@ -78,6 +78,23 @@ from .uncertainty_monitor import UncertaintyMonitor
 logger = logging.getLogger("autorag.pipeline")
 
 
+def _pipeline_step_log_record(trace_id: str, step: PipelineStep) -> dict[str, Any]:
+    """Build a safe pipeline-step log record without step details.
+
+    Pipeline step details can contain user prompts, retrieved document text,
+    generated outlines, or other sensitive data. Those details remain available
+    through the in-process callback and telemetry trace store, but application
+    logs should only receive non-sensitive execution metadata.
+    """
+    return {
+        "event": "pipeline_step",
+        "trace_id": trace_id,
+        "name": step.name,
+        "duration_ms": step.duration_ms,
+        "status": step.status,
+    }
+
+
 class Orchestrator:
     """Agentic RAG orchestrator with iterative retrieval and self-correction.
 
@@ -813,14 +830,7 @@ class Orchestrator:
             if on_step:
                 on_step(step)
             try:
-                logger.info(json.dumps({
-                    "event": "pipeline_step",
-                    "trace_id": trace_id,
-                    "name": step.name,
-                    "duration_ms": step.duration_ms,
-                    "status": step.status,
-                    "details": step.details,
-                }))
+                logger.info(json.dumps(_pipeline_step_log_record(trace_id, step)))
             except Exception:
                 logger.info("pipeline_step trace_id=%s name=%s", trace_id, step.name)
 

--- a/api/tests/test_pipeline_logging.py
+++ b/api/tests/test_pipeline_logging.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.core.orchestrator import _pipeline_step_log_record
+from app.core.telemetry import PipelineStep
+
+
+def test_pipeline_step_log_record_omits_sensitive_details():
+    secret = "SSN-123-45-6789 confidential acquisition target: ProjectNightfall"
+    now = datetime.now(UTC)
+    step = PipelineStep(
+        name="planning",
+        started_at=now,
+        completed_at=now,
+        duration_ms=12.5,
+        status="ok",
+        details={
+            "queries": [secret],
+            "iterations": [{"query": secret, "refined_query": secret}],
+            "conflicts_summary": [f"retrieved text {secret}"],
+            "outline": f"context-derived outline {secret}",
+        },
+    )
+
+    log_record = _pipeline_step_log_record("trace-123", step)
+
+    assert log_record == {
+        "event": "pipeline_step",
+        "trace_id": "trace-123",
+        "name": "planning",
+        "duration_ms": 12.5,
+        "status": "ok",
+    }
+    assert "details" not in log_record
+    assert secret not in repr(log_record)


### PR DESCRIPTION
### Motivation
- Prevent unredacted `PipelineStep.details` (which can contain user prompts, retrieved document snippets, refined queries, and generated outlines) from being written to the `autorag.pipeline` INFO log, avoiding an information-disclosure risk.

### Description
- Add a helper `def _pipeline_step_log_record(trace_id: str, step: PipelineStep) -> dict[str, Any]` that builds a safe log payload containing only non-sensitive metadata (`event`, `trace_id`, `name`, `duration_ms`, `status`).
- Change `record_step()` in `api/app/core/orchestrator.py` to log `json.dumps(_pipeline_step_log_record(trace_id, step))` instead of serializing `step.details`.
- Add a regression test `api/tests/test_pipeline_logging.py` that creates a `PipelineStep` containing a secret and asserts the safe log record omits `details` and the secret.
- Files changed: `api/app/core/orchestrator.py` and `api/tests/test_pipeline_logging.py`.

### Testing
- Ran the regression test with `cd api && uv run pytest tests/test_pipeline_logging.py`, which passed.
- Ran the broader test suite with `cd api && uv run pytest tests/test_pipeline_stages.py tests/test_metrics_alignment.py tests/test_pipeline_logging.py`, with all tests passing (45 passed).
- Ran lint checks with `cd api && uv run ruff check app/core/orchestrator.py tests/test_pipeline_logging.py`, which completed without issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19bc4e370c832792faaa8666182897)