### PR TITLE
Redact provider metadata from query telemetry

### DIFF
--- a/api/app/core/orchestrator.py
+++ b/api/app/core/orchestrator.py
@@ -69,7 +69,12 @@ from .self_rag import get_self_rag_critic
 # Web search disabled for offline-only operation
 # from .web_search import WebSearch, get_web_search
 from .smart_planner import compute_marginal_gain
-from .telemetry import PipelineStep, TelemetryStore
+from .telemetry import (
+    PUBLIC_PROVIDER_ERROR_MESSAGE,
+    PipelineStep,
+    TelemetryStore,
+    pipeline_step_to_public_dict,
+)
 from .trace_export import TraceBundle, create_trace_bundle
 
 # Confidence monitoring
@@ -908,17 +913,7 @@ class Orchestrator:
             )
             record_step(cache_step)
             # Return cached result with updated trace
-            cached_result["steps"] = [
-                {
-                    "name": s.name,
-                    "duration_ms": s.duration_ms,
-                    "details": s.details,
-                    "status": s.status,
-                    "started_at": s.started_at.isoformat(),
-                    "completed_at": s.completed_at.isoformat(),
-                }
-                for s in pipeline_steps
-            ]
+            cached_result["steps"] = [pipeline_step_to_public_dict(s) for s in pipeline_steps]
             cached_result["from_cache"] = True
             return cached_result
 
@@ -1809,8 +1804,8 @@ class Orchestrator:
             gen_start = time.perf_counter()
             provider = self._provider
             gen_details: dict[str, Any] = {
-                "provider": getattr(provider, "base_url", "unknown") if provider else "none",
-                "model": getattr(provider, "default_model", "unknown") if provider else None,
+                "provider": "configured" if provider else "none",
+                "model": "configured" if provider else None,
                 "context_tokens": len(context_text.split()) if context_text else 0,
                 "num_citations": len(citation_payload),
                 "mode": "standard",
@@ -1949,10 +1944,10 @@ For each question:
                             else:
                                 answer = await provider.chat(messages)
                         gen_details["status"] = "success"
-                except ProviderError as exc:
-                    answer = f"Provider error: {exc}"
+                except ProviderError:
+                    answer = PUBLIC_PROVIDER_ERROR_MESSAGE
                     gen_details["status"] = "error"
-                    gen_details["error"] = str(exc)
+                    gen_details["error"] = PUBLIC_PROVIDER_ERROR_MESSAGE
 
             record_step(self._make_step(step_name, gen_start, gen_start_time, gen_details))
             return answer, gen_details
@@ -2398,17 +2393,7 @@ The retrieved evidence contains some conflicting information. When you encounter
         )
 
         # Build step summaries for response
-        steps_out = [
-            {
-                "name": s.name,
-                "duration_ms": s.duration_ms,
-                "details": s.details,
-                "status": s.status,
-                "started_at": s.started_at.isoformat(),
-                "completed_at": s.completed_at.isoformat(),
-            }
-            for s in pipeline_steps
-        ]
+        steps_out = [pipeline_step_to_public_dict(s) for s in pipeline_steps]
 
         result = {
             "answer": answer,
@@ -2579,8 +2564,8 @@ Be helpful, accurate, and concise."""
                 messages.append({"role": "system", "content": memory_context})
             messages.append({"role": "user", "content": query})
 
-            gen_details["provider"] = getattr(provider, "base_url", "unknown")
-            gen_details["model"] = getattr(provider, "default_model", "unknown")
+            gen_details["provider"] = "configured"
+            gen_details["model"] = "configured"
 
             try:
                 if on_token is not None:
@@ -2599,10 +2584,10 @@ Be helpful, accurate, and concise."""
                 else:
                     answer = await provider.chat(messages)
                 gen_details["status"] = "success"
-            except ProviderError as exc:
-                answer = f"Provider error: {exc}"
+            except ProviderError:
+                answer = PUBLIC_PROVIDER_ERROR_MESSAGE
                 gen_details["status"] = "error"
-                gen_details["error"] = str(exc)
+                gen_details["error"] = PUBLIC_PROVIDER_ERROR_MESSAGE
 
         record_step(self._make_step("generation", gen_start, gen_start_time, gen_details))
 
@@ -2638,17 +2623,7 @@ Be helpful, accurate, and concise."""
             started_at=pipeline_start,
         )
 
-        steps_out = [
-            {
-                "name": s.name,
-                "duration_ms": s.duration_ms,
-                "details": s.details,
-                "status": s.status,
-                "started_at": s.started_at.isoformat(),
-                "completed_at": s.completed_at.isoformat(),
-            }
-            for s in pipeline_steps
-        ]
+        steps_out = [pipeline_step_to_public_dict(s) for s in pipeline_steps]
 
         result = {
             "answer": answer,
@@ -2710,17 +2685,7 @@ Be helpful, accurate, and concise."""
             started_at=pipeline_start,
         )
 
-        steps_out = [
-            {
-                "name": s.name,
-                "duration_ms": s.duration_ms,
-                "details": s.details,
-                "status": s.status,
-                "started_at": s.started_at.isoformat(),
-                "completed_at": s.completed_at.isoformat(),
-            }
-            for s in pipeline_steps
-        ]
+        steps_out = [pipeline_step_to_public_dict(s) for s in pipeline_steps]
 
         return {
             "answer": answer,
@@ -2787,17 +2752,7 @@ Be helpful, accurate, and concise."""
             started_at=pipeline_start,
         )
 
-        steps_out = [
-            {
-                "name": s.name,
-                "duration_ms": s.duration_ms,
-                "details": s.details,
-                "status": s.status,
-                "started_at": s.started_at.isoformat(),
-                "completed_at": s.completed_at.isoformat(),
-            }
-            for s in pipeline_steps
-        ]
+        steps_out = [pipeline_step_to_public_dict(s) for s in pipeline_steps]
 
         # Include partial sources even when abstaining
         sources = [

--- a/api/app/core/telemetry.py
+++ b/api/app/core/telemetry.py
@@ -34,6 +34,47 @@ class Trace:
     steps: list[PipelineStep] = field(default_factory=list)
 
 
+PUBLIC_PROVIDER_ERROR_MESSAGE = "Provider request failed; check server logs for details."
+
+
+def sanitize_step_details(step_name: str, details: dict[str, Any] | None) -> dict[str, Any]:
+    """Return step details safe to persist or expose through public APIs.
+
+    Generation steps can otherwise carry provider endpoints, deployment/model IDs,
+    or raw upstream exception text. Keep operational status fields while replacing
+    sensitive connection metadata with coarse, non-identifying values.
+    """
+    safe_details = dict(details or {})
+    if not step_name.startswith("generation"):
+        return safe_details
+
+    provider = safe_details.get("provider")
+    if provider not in (None, "none", "unknown"):
+        safe_details["provider"] = "configured"
+
+    model = safe_details.get("model")
+    if model not in (None, "unknown"):
+        safe_details["model"] = "configured"
+
+    for key in list(safe_details):
+        if "error" in key.lower():
+            safe_details[key] = PUBLIC_PROVIDER_ERROR_MESSAGE
+
+    return safe_details
+
+
+def pipeline_step_to_public_dict(step: PipelineStep) -> dict[str, Any]:
+    """Serialize a pipeline step with sanitized details for responses/traces."""
+    return {
+        "name": step.name,
+        "duration_ms": step.duration_ms,
+        "details": sanitize_step_details(step.name, step.details),
+        "status": step.status,
+        "started_at": step.started_at.isoformat(),
+        "completed_at": step.completed_at.isoformat(),
+    }
+
+
 class TelemetryStore:
     def __init__(self, path: Path | None = None) -> None:
         self._path = Path(path or Path.cwd() / "data" / "traces.json")
@@ -50,7 +91,7 @@ class TelemetryStore:
             started_at=datetime.fromisoformat(data["started_at"]),
             completed_at=datetime.fromisoformat(data["completed_at"]),
             duration_ms=data.get("duration_ms", 0.0),
-            details=data.get("details", {}),
+            details=sanitize_step_details(data["name"], data.get("details", {})),
             status=data.get("status", "completed"),
         )
 
@@ -76,6 +117,7 @@ class TelemetryStore:
             data["steps"] = []
             for step in trace.steps:
                 step_data = asdict(step)
+                step_data["details"] = sanitize_step_details(step.name, step.details)
                 step_data["started_at"] = step.started_at.isoformat()
                 step_data["completed_at"] = step.completed_at.isoformat()
                 data["steps"].append(step_data)
@@ -92,6 +134,17 @@ class TelemetryStore:
     ) -> Trace:
         with self._lock:
             now = datetime.now(UTC)
+            safe_steps = [
+                PipelineStep(
+                    name=step.name,
+                    started_at=step.started_at,
+                    completed_at=step.completed_at,
+                    duration_ms=step.duration_ms,
+                    details=sanitize_step_details(step.name, step.details),
+                    status=step.status,
+                )
+                for step in (steps or [])
+            ]
             trace = Trace(
                 id=str(uuid.uuid4()),
                 started_at=started_at or now,
@@ -99,7 +152,7 @@ class TelemetryStore:
                 prompt=prompt,
                 answer=answer,
                 metrics=metrics or {},
-                steps=steps or [],
+                steps=safe_steps,
             )
             self._traces.append(trace)
             self._persist()

--- a/api/app/routers/monitoring.py
+++ b/api/app/routers/monitoring.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends
 
 from ..core.cache import get_cache_manager
+from ..core.telemetry import pipeline_step_to_public_dict
 from ..schemas.query import TraceOut, TraceStepOut
 from ..services import ServiceContainer, get_container
 
@@ -21,14 +22,7 @@ def traces(container: ServiceContainer = Depends(get_container)):
             answer=trace.answer,
             metrics=trace.metrics,
             steps=[
-                TraceStepOut(
-                    name=s.name,
-                    duration_ms=s.duration_ms,
-                    details=s.details,
-                    status=s.status,
-                    started_at=s.started_at.isoformat(),
-                    completed_at=s.completed_at.isoformat(),
-                )
+                TraceStepOut(**pipeline_step_to_public_dict(s))
                 for s in trace.steps
             ],
         )

--- a/api/app/routers/query.py
+++ b/api/app/routers/query.py
@@ -13,7 +13,7 @@ from fastapi.responses import StreamingResponse
 from ..core.auth import get_auth
 from ..core.document_acl import get_acl_enforcer, resolve_acl_defaults
 from ..core.query_mode import QueryMode
-from ..core.telemetry import PipelineStep
+from ..core.telemetry import PipelineStep, pipeline_step_to_public_dict
 from ..schemas.query import MAX_QUESTION_LENGTH, QueryRequest, QueryResponse, TraceOut, TraceStepOut
 from ..services import ServiceContainer, get_container
 
@@ -130,14 +130,7 @@ async def ask_stream(
     queue: asyncio.Queue[dict | None] = asyncio.Queue()
 
     def serialize_step(step: PipelineStep) -> dict:
-        return {
-            "name": step.name,
-            "duration_ms": step.duration_ms,
-            "details": step.details,
-            "status": step.status,
-            "started_at": step.started_at.isoformat(),
-            "completed_at": step.completed_at.isoformat(),
-        }
+        return pipeline_step_to_public_dict(step)
 
     def on_step(step: PipelineStep) -> None:
         queue.put_nowait({"type": "step", "data": serialize_step(step)})
@@ -202,14 +195,7 @@ def list_traces(container: ServiceContainer = Depends(get_container)):
             answer=trace.answer,
             metrics=trace.metrics,
             steps=[
-                TraceStepOut(
-                    name=s.name,
-                    duration_ms=s.duration_ms,
-                    details=s.details,
-                    status=s.status,
-                    started_at=s.started_at.isoformat(),
-                    completed_at=s.completed_at.isoformat(),
-                )
+                TraceStepOut(**pipeline_step_to_public_dict(s))
                 for s in trace.steps
             ],
         )

--- a/api/tests/test_security_exposure.py
+++ b/api/tests/test_security_exposure.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -10,6 +11,12 @@ from starlette.requests import Request
 
 from app.core import auth as auth_module
 from app.core.security_middleware import verify_api_key
+from app.core.telemetry import (
+    PUBLIC_PROVIDER_ERROR_MESSAGE,
+    PipelineStep,
+    TelemetryStore,
+    pipeline_step_to_public_dict,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -76,3 +83,43 @@ async def test_exposed_mode_fails_closed_without_auth(monkeypatch: pytest.Monkey
     assert exc_info.value.status_code == 503
 
     _reset_auth()
+
+
+def test_generation_step_details_redact_provider_metadata_before_exposure(tmp_path: Path) -> None:
+    step = PipelineStep(
+        name="generation",
+        started_at=datetime.now(UTC),
+        completed_at=datetime.now(UTC),
+        duration_ms=12.0,
+        details={
+            "provider": "http://alice:secretpass@internal-provider.local:8080/private",
+            "model": "private-deployment/gpt-4o-prod",
+            "status": "error",
+            "error": (
+                "Provider error 503 for url "
+                "http://alice:secretpass@internal-provider.local:8080/private"
+            ),
+            "uncertainty_fallback_error": "retry failed against internal-provider.local",
+        },
+        status="error",
+    )
+
+    public_step = pipeline_step_to_public_dict(step)
+
+    assert public_step["details"]["provider"] == "configured"
+    assert public_step["details"]["model"] == "configured"
+    assert public_step["details"]["error"] == PUBLIC_PROVIDER_ERROR_MESSAGE
+    assert public_step["details"]["uncertainty_fallback_error"] == PUBLIC_PROVIDER_ERROR_MESSAGE
+    assert "secretpass" not in str(public_step)
+    assert "internal-provider.local" not in str(public_step)
+    assert "private-deployment" not in str(public_step)
+
+    trace_path = tmp_path / "traces.json"
+    store = TelemetryStore(trace_path)
+    trace = store.record("prompt", "answer", steps=[step])
+
+    assert trace.steps[0].details == public_step["details"]
+    persisted = trace_path.read_text(encoding="utf-8")
+    assert "secretpass" not in persisted
+    assert "internal-provider.local" not in persisted
+    assert "private-deployment" not in persisted


### PR DESCRIPTION
### Motivation
- The generation pipeline recorded provider connection metadata (provider base URL, model identifier) and raw provider error text in step details which were returned from `/query` and persisted to traces, exposing internal endpoints and possible embedded credentials. 
- The goal is to remove sensitive connection details from telemetry and API responses while preserving useful operational signals (status, durations, counts).

### Description
- Add `sanitize_step_details` and `pipeline_step_to_public_dict` to `api/app/core/telemetry.py` and introduce `PUBLIC_PROVIDER_ERROR_MESSAGE` to replace raw provider errors and redact provider/model values for generation steps. 
- Sanitize step details on decode/persist/record in `TelemetryStore` so persisted traces never contain raw provider endpoints, model names, or upstream error strings. 
- Replace construction of `steps_out` in `Orchestrator` responses with the shared `pipeline_step_to_public_dict` and stop copying raw `gen_details` provider/model strings into public outputs, and replace raw provider exceptions with the public message. 
- Update streaming and trace endpoints in `api/app/routers/query.py` and `api/app/routers/monitoring.py` to use the sanitized pipeline-step serializer so live streams and `/traces` responses do not leak provider metadata. 
- Add a regression test `test_generation_step_details_redact_provider_metadata_before_exposure` verifying redaction of provider URLs, credentials, private model identifiers, and provider error text before exposure and persistence.

### Testing
- Ran style checks with `uv run ruff check app/core/telemetry.py app/core/orchestrator.py app/routers/query.py app/routers/monitoring.py tests/test_security_exposure.py` which passed. 
- Ran the regression test with `uv run pytest tests/test_security_exposure.py` which passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19ba2455348327a036cf8d3f3b888c)