### PR TITLE
Fix dense_k zero coverage crash

### DIFF
--- a/api/app/core/config_store.py
+++ b/api/app/core/config_store.py
@@ -30,7 +30,16 @@ class ConfigStore:
     def read(self) -> AppConfig:
         with self._lock:
             data = json.loads(self._path.read_text(encoding="utf-8"))
-            return AppConfig.model_validate(data)
+            repaired = False
+            retrieval = data.get("retrieval") if isinstance(data, dict) else None
+            if isinstance(retrieval, dict) and retrieval.get("dense_k") == 0:
+                retrieval["dense_k"] = 1
+                repaired = True
+            cfg = AppConfig.model_validate(data)
+            if repaired:
+                payload = cfg.model_dump(mode="json")
+                self._path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            return cfg
 
     def write(self, cfg: AppConfig) -> AppConfig:
         payload = cfg.model_dump(mode="json")

--- a/api/app/core/orchestrator.py
+++ b/api/app/core/orchestrator.py
@@ -2333,7 +2333,8 @@ The retrieved evidence contains some conflicting information. When you encounter
         total_tokens = len(context.split()) if context else 0
         coverage = 0.0
         if plan.steps:
-            coverage = len(chunks) / plan.steps[0].dense_k
+            dense_k = max(1, plan.steps[0].dense_k)
+            coverage = len(chunks) / dense_k
 
         total_duration_ms = sum(s.duration_ms for s in pipeline_steps)
         retrieval_mode = "standard"

--- a/api/app/schemas/config.py
+++ b/api/app/schemas/config.py
@@ -320,7 +320,7 @@ class RetrievalDefaults(BaseModel):
     """Retrieval configuration optimized for hybrid retrieval."""
 
     hybrid: bool = True
-    dense_k: int = 5
+    dense_k: int = Field(default=5, ge=1)
     sparse_k: int = 10
     dense_weight: float = 0.6
     sparse_weight: float = 0.4

--- a/api/tests/api/test_endpoints.py
+++ b/api/tests/api/test_endpoints.py
@@ -59,6 +59,19 @@ def test_config_roundtrip(client: TestClient) -> None:
     assert update.json()["profile"] == "Smoke"
 
 
+def test_config_rejects_zero_dense_k(client: TestClient) -> None:
+    resp = client.get("/config")
+    assert resp.status_code == 200
+    config = resp.json()
+    config["retrieval"]["dense_k"] = 0
+
+    update = client.put("/config", json=config)
+
+    assert update.status_code == 422
+    detail = str(update.json()["detail"]).lower()
+    assert "dense_k" in detail
+
+
 def test_model_download_rejects_unconfigured_model(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/api/tests/core/test_config_store.py
+++ b/api/tests/core/test_config_store.py
@@ -1,0 +1,22 @@
+"""Tests for persisted configuration handling."""
+
+from __future__ import annotations
+
+import json
+
+from app.core.config_store import ConfigStore
+from app.schemas.config import AppConfig
+
+
+def test_config_store_repairs_persisted_zero_dense_k(tmp_path) -> None:
+    path = tmp_path / "config.json"
+    payload = AppConfig().model_dump(mode="json")
+    payload["retrieval"]["dense_k"] = 0
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    store = ConfigStore(path)
+
+    cfg = store.read()
+
+    assert cfg.retrieval.dense_k == 1
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    assert persisted["retrieval"]["dense_k"] == 1


### PR DESCRIPTION
### Motivation
- Prevent a ZeroDivisionError in `Orchestrator.answer()` caused by `retrieval.dense_k` being set to `0` via the config API.
- Ensure invalid persisted configs with `dense_k=0` do not keep the service in a broken state after deployment.

### Description
- Add a schema constraint to `RetrievalDefaults.dense_k` so it is defined as `Field(default=5, ge=1)` in `api/app/schemas/config.py`, preventing `dense_k=0` from being accepted by the API.
- Make coverage calculation in `api/app/core/orchestrator.py` defensive by using `dense_k = max(1, plan.steps[0].dense_k)` before dividing to avoid division by zero.
- Repair persisted configs on load in `api/app/core/config_store.py` by normalizing an on-disk `retrieval.dense_k == 0` to `1` and rewriting the stored config.
- Add regression tests: an API test that verifies `/config` rejects `dense_k=0` (`api/tests/api/test_endpoints.py`) and a config-store test that verifies persisted `dense_k=0` is repaired on load (`api/tests/core/test_config_store.py`).

### Testing
- Ran linting checks with `uv run ruff check ...` and they passed.
- Ran targeted pytest runs: `tests/api/test_endpoints.py::test_config_rejects_zero_dense_k` and `tests/core/test_config_store.py::test_config_store_repairs_persisted_zero_dense_k`, and both passed.
- A broader smoke test that exercises ingest/query (`tests/api/test_endpoints.py::test_document_ingest_query_and_evaluation`) still fails in this environment due to the optional dependency `sentence-transformers` not being installed (dense retrieval disabled), which is unrelated to the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19b811647883279b4a1bb24e0522c1)