### PR TITLE
Reject duplicate document titles by default and thread on_duplicate through ingestion

### DIFF
--- a/api/app/core/documents.py
+++ b/api/app/core/documents.py
@@ -187,7 +187,7 @@ class DocumentStore:
         title: str,
         text: str,
         metadata: dict[str, str] | None = None,
-        on_duplicate: str = "replace",
+        on_duplicate: str = "reject",
     ) -> Document:
         normalized = self._normalize_title(title)
         if not normalized:

--- a/api/app/core/ingest.py
+++ b/api/app/core/ingest.py
@@ -96,6 +96,7 @@ class IngestPipeline:
         sync: bool = False,
         langextract_profile_override: str | None = None,
         langextract_prompt_override: str | None = None,
+        on_duplicate: str = "reject",
     ) -> IngestResult:
         """Ingest text with content hash tracking for change detection."""
         meta = self._prepare_metadata(metadata)
@@ -130,7 +131,7 @@ class IngestPipeline:
         contextualized = self._contextualize_chunks(chunks, title, meta)
         combined = "\n\n".join(contextualized)
 
-        doc = self._store.add(title=title, text=combined, metadata=meta)
+        doc = self._store.add(title=title, text=combined, metadata=meta, on_duplicate=on_duplicate)
 
         self._persist_langextract_artifact(doc.id, title, langextract_result, doc)
         self._log_langextract_audit(doc.id, title, langextract_result)
@@ -174,6 +175,7 @@ class IngestPipeline:
         sync: bool = False,
         langextract_profile_override: str | None = None,
         langextract_prompt_override: str | None = None,
+        on_duplicate: str = "reject",
     ) -> IngestResult:
         meta = {**(metadata or {})}
         meta.setdefault("filename", title)
@@ -224,6 +226,7 @@ class IngestPipeline:
             sync=sync,
             langextract_profile_override=langextract_profile_override,
             langextract_prompt_override=langextract_prompt_override,
+            on_duplicate=on_duplicate,
         )
 
     def ingest_incremental(
@@ -258,8 +261,8 @@ class IngestPipeline:
                     content_hash=content_hash,
                 )
 
-        # Proceed with full ingest (duplicate titles handled in store)
-        return self.ingest_text(title=title, text=text, metadata=metadata)
+        # Proceed with full ingest and intentionally replace the existing title when changed.
+        return self.ingest_text(title=title, text=text, metadata=metadata, on_duplicate="replace")
 
     def _run_langextract(
         self,

--- a/api/tests/test_document_store_duplicates.py
+++ b/api/tests/test_document_store_duplicates.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+
+from app.core.documents import DocumentStore
+
+
+def test_document_store_rejects_duplicate_titles_by_default(tmp_path):
+    store = DocumentStore(path=tmp_path / "documents.db")
+    original = store.add(title="Victim Report", text="original", metadata={"owner": "victim"})
+
+    with pytest.raises(ValueError, match="Document title already exists"):
+        store.add(title="  victim report  ", text="attacker", metadata={"owner": "attacker"})
+
+    stored = store.get(original.id)
+    assert stored is not None
+    assert stored.id == original.id
+    assert stored.text == "original"
+    assert stored.metadata["owner"] == "victim"
+    assert len(store.list()) == 1
+
+
+def test_document_store_can_explicitly_replace_duplicate_titles(tmp_path):
+    store = DocumentStore(path=tmp_path / "documents.db")
+    original = store.add(title="Victim Report", text="original", metadata={"owner": "victim"})
+
+    replacement = store.add(
+        title="  victim report  ",
+        text="replacement",
+        metadata={"owner": "trusted-updater"},
+        on_duplicate="replace",
+    )
+
+    assert replacement.id == original.id
+    stored = store.get(original.id)
+    assert stored is not None
+    assert stored.text == "replacement"
+    assert stored.metadata["owner"] == "trusted-updater"
+    assert len(store.list()) == 1


### PR DESCRIPTION
### Motivation
- Prevent silent overwrites where a malicious or accidental re-upload with a normalized existing title would reuse the existing document ID and replace its text/metadata.
- Ensure public ingestion paths use a safe default of rejection for duplicate titles while keeping an explicit opt-in for trusted replacements.

### Description
- Change `DocumentStore.add()` default from `on_duplicate="replace"` to `on_duplicate="reject"` so normalized duplicate titles raise a `ValueError` by default.
- Add an `on_duplicate` parameter to `IngestPipeline.ingest_text()` and `ingest_file()` with a default of `"reject"` and pass it through to `DocumentStore.add()` to make ingestion behavior explicit.
- Preserve intentional replacement during incremental updates by calling `ingest_text(..., on_duplicate="replace")` from `ingest_incremental()` when content has changed.
- Add `api/tests/test_document_store_duplicates.py` with regression tests that verify default rejection of normalized duplicate titles and explicit replacement via `on_duplicate="replace"`.

### Testing
- Ran `pytest` on the new test file (`tests/test_document_store_duplicates.py`) and the integration pipeline test, and all requested tests passed (2 tests for the duplicate-store file and the additional integration check passed).
- Ran `ruff` style checks on the modified files and there were no linter errors.
- Smoke-tested the incremental ingest flow to confirm explicit replacement remains possible and safe rejection is the default.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36d4a980dc832797c72ebca52b7170)