### PR TITLE
Isolate disk-backed full-query cache by query mode

### DIFF
--- a/api/app/core/orchestrator.py
+++ b/api/app/core/orchestrator.py
@@ -667,6 +667,7 @@ class Orchestrator:
         history: list[dict[str, str]] | None = None,
         conversation_id: str | None = None,
         cache_scope: str | None = None,
+        query_mode: QueryMode | None = None,
     ) -> str | None:
         """Create a request-scope fingerprint for full-answer cache entries.
 
@@ -674,13 +675,15 @@ class Orchestrator:
         must vary on request-local inputs that can change authorization or model
         context.  Routers may pass an already-hashed user/ACL scope in
         ``cache_scope``; direct callers are still protected by folding document
-        filters, chat history, and memory conversation IDs into this fingerprint.
+        filters, chat history, memory conversation IDs, and query mode into this
+        fingerprint.
         """
         scope_payload = {
             "cache_scope": cache_scope or "",
             "document_ids": sorted(document_ids or []),
             "history": history or [],
             "conversation_id": conversation_id or "",
+            "query_mode": query_mode.value if query_mode else "",
         }
         if not any(scope_payload.values()):
             return None
@@ -850,11 +853,20 @@ class Orchestrator:
             return list(seen.values())
 
         cache_manager = get_cache_manager()
+
+        # P0.1: Resolve query mode from parameter or config before cache lookup so
+        # grounded and open-domain answers cannot share a full-answer cache entry.
+        effective_query_mode = query_mode
+        if effective_query_mode is None:
+            config_mode = getattr(self._config, "query_mode", "grounded")
+            effective_query_mode = QueryMode(config_mode) if config_mode in ("grounded", "open_domain") else QueryMode.GROUNDED
+
         query_cache_scope = self._query_cache_scope(
             document_ids=document_ids,
             history=history,
             conversation_id=conversation_id,
             cache_scope=cache_scope,
+            query_mode=effective_query_mode,
         )
         cache_hash = self._cache_config_hash(document_ids, query_cache_scope)
 
@@ -865,12 +877,6 @@ class Orchestrator:
             cache_corpus_version = self._retrieval.get_corpus_version()
         if hasattr(self._retrieval, 'get_retrieval_mode_flags'):
             cache_retrieval_mode = self._retrieval.get_retrieval_mode_flags()
-
-        # P0.1: Resolve query mode from parameter or config
-        effective_query_mode = query_mode
-        if effective_query_mode is None:
-            config_mode = getattr(self._config, "query_mode", "grounded")
-            effective_query_mode = QueryMode(config_mode) if config_mode in ("grounded", "open_domain") else QueryMode.GROUNDED
 
         # P0.3: Get current preset ID for cache key
         current_preset_id = getattr(self._config.retrieval, "_preset_level", "balanced") if self._config else "balanced"

--- a/api/tests/test_query_cache_security.py
+++ b/api/tests/test_query_cache_security.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from app.core.orchestrator import Orchestrator
 from app.core.persistence import DiskQueryCache, QueryCacheConfig
+from app.core.query_mode import QueryMode
 
 
 def test_disk_query_cache_varies_by_scope_key(tmp_path):
@@ -61,5 +62,17 @@ def test_orchestrator_cache_scope_includes_request_context():
     assert base_scope == same_scope
     assert base_scope != other_doc_scope
     assert base_scope != history_scope
+    grounded_scope = orchestrator._query_cache_scope(
+        document_ids=["doc-a"],
+        cache_scope="user-a",
+        query_mode=QueryMode.GROUNDED,
+    )
+    open_domain_scope = orchestrator._query_cache_scope(
+        document_ids=["doc-a"],
+        cache_scope="user-a",
+        query_mode=QueryMode.OPEN_DOMAIN,
+    )
+
     assert history_scope != other_history_scope
+    assert grounded_scope != open_domain_scope
     assert orchestrator._query_cache_scope() is None


### PR DESCRIPTION
### Motivation

- Prevent cross-request information leakage where a cached full-answer for one request context (e.g., grounded vs open-domain) could be replayed to a different context and expose private snippets or history.

### Description

- Add `query_mode` parameter to `Orchestrator._query_cache_scope()` and include `query_mode` in the scope payload hashed into the cache scope key. 
- Resolve the effective `query_mode` earlier in `Orchestrator.answer()` before the cache lookup and pass it into `_query_cache_scope()` so the disk cache key varies by grounded vs open-domain requests. 
- Update `api/tests/test_query_cache_security.py` to import `QueryMode` and assert that `GROUNDED` and `OPEN_DOMAIN` produce distinct cache scopes. 
- Minor updates to ensure the cache scope is generated with request-local context including document filters, history, conversation id, and query mode.

### Testing

- Ran the security regression tests with `cd api && uv run pytest tests/test_query_cache_security.py`, which executed the file's tests and reported `2 passed`.
- Ran style checks with `cd api && uv run ruff check app/core/orchestrator.py tests/test_query_cache_security.py`, which completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36d4db5058832792f23225e3088849)