### PR TITLE
Fix conversation memory principal scoping

### DIFF
--- a/api/app/routers/query.py
+++ b/api/app/routers/query.py
@@ -14,10 +14,33 @@ from ..core.auth import get_auth
 from ..core.document_acl import get_acl_enforcer, resolve_acl_defaults
 from ..core.query_mode import QueryMode
 from ..core.telemetry import PipelineStep, pipeline_step_to_public_dict
-from ..schemas.query import MAX_QUESTION_LENGTH, QueryRequest, QueryResponse, TraceOut, TraceStepOut
+from ..schemas.query import (
+    MAX_QUESTION_LENGTH,
+    QueryRequest,
+    QueryResponse,
+    TraceOut,
+    TraceStepOut,
+)
 from ..services import ServiceContainer, get_container
 
 router = APIRouter(prefix="/query", tags=["query"])
+
+
+def _scoped_conversation_id(
+    user_id: str | None, conversation_id: str | None
+) -> str | None:
+    """Return an internal, principal-bound key for conversation memory.
+
+    Clients can choose human-readable conversation IDs, but the shared in-process
+    memory store must never use that value directly.  Hash the authenticated
+    principal (or the public namespace when auth is disabled) with the client ID
+    so collisions across users cannot read or poison each other's memory.
+    """
+    if not conversation_id:
+        return None
+    principal = user_id or "public"
+    digest = hashlib.sha256(f"{principal}:{conversation_id}".encode()).hexdigest()
+    return f"conversation:{digest}"
 
 
 def _make_cache_scope(
@@ -46,20 +69,28 @@ def _resolve_query_access(
     payload: QueryRequest,
     request: Request,
     container: ServiceContainer,
-) -> tuple[list[str] | None, str | None]:
+) -> tuple[list[str] | None, str | None, str | None]:
     user_id = getattr(request.state, "user_id", None)
     scopes = getattr(request.state, "scopes", [])
     auth_enabled = get_auth().require_auth()
 
     if not auth_enabled:
         document_ids = payload.document_ids
-        return document_ids, _make_cache_scope(None, document_ids, payload.conversation_id)
+        return (
+            document_ids,
+            _make_cache_scope(None, document_ids, payload.conversation_id),
+            _scoped_conversation_id(None, payload.conversation_id),
+        )
 
     default_public, _ = resolve_acl_defaults(auth_enabled)
     enforcer = get_acl_enforcer(default_public=default_public)
 
     if "admin" in scopes:
-        return payload.document_ids, _make_cache_scope(user_id, payload.document_ids, payload.conversation_id)
+        return (
+            payload.document_ids,
+            _make_cache_scope(user_id, payload.document_ids, payload.conversation_id),
+            _scoped_conversation_id(user_id, payload.conversation_id),
+        )
 
     docs = container.document_store.list()
 
@@ -70,11 +101,21 @@ def _resolve_query_access(
             if enforcer.check_access(doc_id, user_id, "read")[0]
         ]
         if not allowed:
-            raise HTTPException(status_code=403, detail="No access to requested documents")
-        return allowed, _make_cache_scope(user_id, allowed, payload.conversation_id)
+            raise HTTPException(
+                status_code=403, detail="No access to requested documents"
+            )
+        return (
+            allowed,
+            _make_cache_scope(user_id, allowed, payload.conversation_id),
+            _scoped_conversation_id(user_id, payload.conversation_id),
+        )
 
     if not docs:
-        return None, _make_cache_scope(user_id, None, payload.conversation_id)
+        return (
+            None,
+            _make_cache_scope(user_id, None, payload.conversation_id),
+            _scoped_conversation_id(user_id, payload.conversation_id),
+        )
 
     allowed_ids = [
         doc.id for doc in docs if enforcer.check_access(doc.id, user_id, "read")[0]
@@ -83,8 +124,16 @@ def _resolve_query_access(
         raise HTTPException(status_code=403, detail="No accessible documents")
 
     if len(allowed_ids) == len(docs):
-        return None, _make_cache_scope(user_id, None, payload.conversation_id)
-    return allowed_ids, _make_cache_scope(user_id, allowed_ids, payload.conversation_id)
+        return (
+            None,
+            _make_cache_scope(user_id, None, payload.conversation_id),
+            _scoped_conversation_id(user_id, payload.conversation_id),
+        )
+    return (
+        allowed_ids,
+        _make_cache_scope(user_id, allowed_ids, payload.conversation_id),
+        _scoped_conversation_id(user_id, payload.conversation_id),
+    )
 
 
 @router.post("", response_model=QueryResponse)
@@ -100,15 +149,19 @@ async def ask(
             status_code=400,
             detail=f"Question exceeds maximum length of {MAX_QUESTION_LENGTH} characters",
         )
-    document_ids, cache_scope = _resolve_query_access(payload, request, container)
+    document_ids, cache_scope, memory_conversation_id = _resolve_query_access(
+        payload, request, container
+    )
     result = await container.orchestrator.answer(
         payload.question,
         document_ids=document_ids,
         history=payload.history,
-        conversation_id=payload.conversation_id,
+        conversation_id=memory_conversation_id,
         query_mode=QueryMode(payload.query_mode) if payload.query_mode else None,
         cache_scope=cache_scope,
     )
+    if payload.conversation_id:
+        result.setdefault("metrics", {})["conversation_id"] = payload.conversation_id
     return QueryResponse(**result)
 
 
@@ -126,7 +179,9 @@ async def ask_stream(
             detail=f"Question exceeds maximum length of {MAX_QUESTION_LENGTH} characters",
         )
 
-    document_ids, cache_scope = _resolve_query_access(payload, request, container)
+    document_ids, cache_scope, memory_conversation_id = _resolve_query_access(
+        payload, request, container
+    )
     queue: asyncio.Queue[dict | None] = asyncio.Queue()
 
     def serialize_step(step: PipelineStep) -> dict:
@@ -155,10 +210,16 @@ async def ask_stream(
                 on_stage=on_stage,
                 on_progress=on_progress,
                 history=payload.history,
-                conversation_id=payload.conversation_id,
-                query_mode=QueryMode(payload.query_mode) if payload.query_mode else None,
+                conversation_id=memory_conversation_id,
+                query_mode=(
+                    QueryMode(payload.query_mode) if payload.query_mode else None
+                ),
                 cache_scope=cache_scope,
             )
+            if payload.conversation_id:
+                result.setdefault("metrics", {})[
+                    "conversation_id"
+                ] = payload.conversation_id
             await queue.put({"type": "result", "data": result})
         except Exception as exc:
             await queue.put({"type": "error", "data": {"message": str(exc)}})
@@ -176,13 +237,15 @@ async def ask_stream(
                 payload = json.dumps(item, default=_json_default)
             except Exception as exc:
                 payload = json.dumps(
-                    {"type": "error", "data": {"message": f"Stream serialization error: {exc}"}},
+                    {
+                        "type": "error",
+                        "data": {"message": f"Stream serialization error: {exc}"},
+                    },
                     default=_json_default,
                 )
             yield f"data: {payload}\n\n"
 
     return StreamingResponse(event_stream(), media_type="text/event-stream")
-
 
 
 @router.get("/traces", response_model=list[TraceOut])
@@ -195,13 +258,16 @@ def list_traces(container: ServiceContainer = Depends(get_container)):
             answer=trace.answer,
             metrics=trace.metrics,
             steps=[
-                TraceStepOut(**pipeline_step_to_public_dict(s))
-                for s in trace.steps
+                TraceStepOut(**pipeline_step_to_public_dict(s)) for s in trace.steps
             ],
         )
         for trace in traces
     ]
+
+
 @router.post("/cancel")
-async def cancel_trace(trace_id: str, container: ServiceContainer = Depends(get_container)):
+async def cancel_trace(
+    trace_id: str, container: ServiceContainer = Depends(get_container)
+):
     container.orchestrator.cancel_trace(trace_id)
     return {"status": "cancelled", "trace_id": trace_id}

--- a/api/tests/api/test_endpoints.py
+++ b/api/tests/api/test_endpoints.py
@@ -638,3 +638,16 @@ def test_upload_accepts_langextract_override_fields(client: TestClient) -> None:
     docs = client.get("/documents")
     assert docs.status_code == 200
     assert docs.json()[0]["metadata"]["ocr_policy"] == "dedicated_ocr"
+
+
+def test_scoped_conversation_id_is_bound_to_principal() -> None:
+    from app.routers.query import _scoped_conversation_id
+
+    alice_key = _scoped_conversation_id("alice", "shared-session")
+    bob_key = _scoped_conversation_id("bob", "shared-session")
+
+    assert alice_key is not None
+    assert bob_key is not None
+    assert alice_key != bob_key
+    assert "shared-session" not in alice_key
+    assert _scoped_conversation_id("alice", None) is None


### PR DESCRIPTION
### Motivation
- Prevent cross-user memory disclosure and poisoning by ensuring client-supplied `conversation_id` is not used directly as the in-process memory key and is bound to the authenticated principal (or a public namespace when auth is disabled).

### Description
- Add `_scoped_conversation_id(user_id, conversation_id)` which returns an internal, principal-bound hashed conversation key and never exposes the raw client ID to the memory store; implemented in `api/app/routers/query.py`.
- Change `_resolve_query_access` to return a third value `memory_conversation_id` (the scoped key) and use that value when calling `Orchestrator.answer` for both standard and streaming query endpoints so memory reads/writes are isolated by principal.
- Preserve the original client-visible `conversation_id` in response metrics by injecting it into `result['metrics']['conversation_id']` when present so users still see their requested ID in telemetry without affecting memory isolation.
- Add a regression test `test_scoped_conversation_id_is_bound_to_principal` in `api/tests/api/test_endpoints.py` that asserts the same client `conversation_id` yields distinct internal keys for different principals and that the raw ID is not present in the internal key.

### Testing
- Ran `python -m py_compile api/app/routers/query.py api/tests/api/test_endpoints.py` to validate syntax, which succeeded. 
- Ran unit test `tests/api/test_endpoints.py::test_scoped_conversation_id_is_bound_to_principal` inside the project virtualenv, which passed. 
- Ran a targeted integration run for three tests (`test_scoped_conversation_id_is_bound_to_principal`, `test_document_ingest_query_and_evaluation`, `test_streaming_query_accepts_grounded_mode`) inside the virtualenv: two tests passed and `test_document_ingest_query_and_evaluation` failed because `sentence-transformers` is not installed in this environment, disabling dense retrieval and causing no evidence chunks to be returned; this failure is environmental and not related to the memory scoping change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36d48198588327b7b3c62b490033da)