### PR TITLE
Fix percent-encoded UI proxy guard bypass

### DIFF
--- a/src/lib/api-proxy.test.ts
+++ b/src/lib/api-proxy.test.ts
@@ -28,14 +28,24 @@ describe("API proxy management-route guard", () => {
   test("allows status APIs and unrelated application APIs", () => {
     expect(isSensitiveManagementApiPath("/api/artifacts/status")).toBe(false);
     expect(isSensitiveManagementApiPath("/api/cache/status")).toBe(false);
+    expect(isSensitiveManagementApiPath("/api/%63ache/status")).toBe(false);
     expect(isSensitiveManagementApiPath("/query")).toBe(false);
+  });
+
+  test("identifies sensitive management APIs with percent-encoded prefixes", () => {
+    expect(isSensitiveManagementApiPath("/api/%74races/download")).toBe(true);
+    expect(isSensitiveManagementApiPath("/api/%61rtifacts/graph")).toBe(true);
+    expect(isSensitiveManagementApiPath("/api/%63ache/clear")).toBe(true);
+    expect(isSensitiveManagementApiPath("/api/cache%2fclear")).toBe(true);
   });
 
   test("blocks sensitive APIs while backend API-key auth is disabled", () => {
     process.env.AUTORAG_AUTH_ENABLED = "false";
 
     expect(isProxyRequestAllowed("/api/traces/last")).toBe(false);
+    expect(isProxyRequestAllowed("/api/%74races/last")).toBe(false);
     expect(isProxyRequestAllowed("/api/cache/clear")).toBe(false);
+    expect(isProxyRequestAllowed("/api/%63ache/clear")).toBe(false);
     expect(isProxyRequestAllowed("/api/artifacts/status")).toBe(true);
   });
 
@@ -61,7 +71,13 @@ describe("API proxy management-route guard", () => {
       "/__api",
     );
 
+    const encodedProxyResponse = await proxyApiRequest(
+      new Request("http://ui.example/api/%63ache/clear?include_disk=true", { method: "DELETE" }),
+      "",
+    );
+
     expect(legacyProxyResponse.status).toBe(403);
     expect(prefixedProxyResponse.status).toBe(403);
+    expect(encodedProxyResponse.status).toBe(403);
   });
 });

--- a/src/lib/api-proxy.ts
+++ b/src/lib/api-proxy.ts
@@ -27,8 +27,14 @@ export const getBackendPath = (requestPath: string, prefix: string): string => (
     : requestPath
 );
 
+const decodePercentEncodedPath = (path: string): string => (
+  path.replace(/%([0-9a-fA-F]{2})/g, (_, hex: string) => (
+    String.fromCharCode(Number.parseInt(hex, 16))
+  ))
+);
+
 export const isSensitiveManagementApiPath = (path: string): boolean => {
-  const normalizedPath = path.replace(/\/+$/, "") || "/";
+  const normalizedPath = decodePercentEncodedPath(path).replace(/\/+$/, "") || "/";
 
   if (PUBLIC_MANAGEMENT_STATUS_PATHS.has(normalizedPath)) {
     return false;


### PR DESCRIPTION
### Motivation
- The UI proxy guard compared raw request path strings to literal sensitive prefixes, which allowed percent-encoded prefixes (e.g. `/api/%63ache/clear`) to bypass the denylist and reach sensitive FastAPI routes after backend decoding.
- Canonicalizing percent-encoded bytes before matching is required to ensure the proxy blocks the same sensitive routes the backend will route to after decoding.

### Description
- Add a `decodePercentEncodedPath` helper to `src/lib/api-proxy.ts` to percent-decode path bytes before normalization. 
- Use the decoder inside `isSensitiveManagementApiPath` so sensitive prefix checks operate on the decoded, trailing-slash-trimmed path. 
- Expand `src/lib/api-proxy.test.ts` with regression tests that cover percent-encoded sensitive prefixes, encoded-slash variants, encoded public status routes, and ensure `proxyApiRequest` returns `403` for encoded sensitive paths when API auth is disabled. 
- Preserve existing behavior for literal paths and public status endpoints while only changing the canonicalization used for the guard.

### Testing
- Ran `bun test src/lib/api-proxy.test.ts` and all tests passed (`7 pass`, targeted regression tests included). 
- Ran the TypeScript check via `bun run typecheck` (`tsc --noEmit`) with no type errors reported. 
- Added tests exercise `isSensitiveManagementApiPath` and `proxyApiRequest` to validate the fix for encoded-path bypasses.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36d3a047388327b07e0b7dbfed0bce)