### PR TITLE
Invalidate query caches after document deletion

### DIFF
--- a/api/app/routers/documents.py
+++ b/api/app/routers/documents.py
@@ -5,12 +5,20 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
 
 from ..core.auth import get_auth
+from ..core.cache import get_cache_manager
 from ..core.document_acl import get_acl_enforcer, get_acl_store, resolve_acl_defaults
 from ..core.document_parser import build_preview_from_document_metadata
+from ..core.persistence import get_disk_query_cache
 from ..schemas.documents import DocumentOut, DocumentPreviewResponse, IngestResponse, IngestTextRequest
 from ..services import ServiceContainer, get_container
 
 router = APIRouter(prefix="/documents", tags=["documents"])
+
+
+def _invalidate_query_caches_after_document_mutation() -> None:
+    """Prevent stale query responses from exposing deleted document content."""
+    get_cache_manager().queries.invalidate_all()
+    get_disk_query_cache().clear()
 
 
 def _ensure_document_read_access(document_id: str, request: Request) -> None:
@@ -141,6 +149,7 @@ def delete_document(
     container.document_store.delete(document_id)
     get_acl_store().delete(document_id)
     container.retrieval_engine.build()
+    _invalidate_query_caches_after_document_mutation()
 
 
 @router.delete("", status_code=204)
@@ -156,6 +165,7 @@ def delete_all_documents(
     container.document_store.clear()
     get_acl_store().clear()
     container.retrieval_engine.build()
+    _invalidate_query_caches_after_document_mutation()
 
 
 @router.post("/upload", response_model=IngestResponse)

--- a/api/tests/test_query_cache_security.py
+++ b/api/tests/test_query_cache_security.py
@@ -63,3 +63,67 @@ def test_orchestrator_cache_scope_includes_request_context():
     assert base_scope != history_scope
     assert history_scope != other_history_scope
     assert orchestrator._query_cache_scope() is None
+
+
+def test_document_mutation_invalidates_in_memory_and_disk_query_caches(tmp_path, monkeypatch):
+    """Document delete handlers must drop cached answers that may contain deleted text."""
+    from app.core.cache import get_cache_manager
+    from app.routers import documents
+
+    disk_cache = DiskQueryCache(QueryCacheConfig(db_path=tmp_path / "query_cache.db"))
+    monkeypatch.setattr(documents, "get_disk_query_cache", lambda: disk_cache)
+
+    memory_cache = get_cache_manager().queries
+    memory_cache.invalidate_all()
+    try:
+        memory_cache.set(
+            "What is the launch code?",
+            {"answer": "SECRET-ALPHA-12345", "chunks": [{"snippet": "SECRET-ALPHA-12345"}]},
+            config_hash="cfg",
+            corpus_version="v1",
+            retrieval_mode=1,
+        )
+        disk_cache.set(
+            "What is the launch code?",
+            {"answer": "SECRET-ALPHA-12345", "chunks": [{"snippet": "SECRET-ALPHA-12345"}]},
+            corpus_version="v1",
+            retrieval_mode=1,
+            preset_id="balanced",
+            model_ids={"generator": "test-model"},
+            scope_key="scope",
+        )
+
+        assert memory_cache.get(
+            "What is the launch code?",
+            config_hash="cfg",
+            corpus_version="v1",
+            retrieval_mode=1,
+        ) is not None
+        assert disk_cache.get(
+            "What is the launch code?",
+            corpus_version="v1",
+            retrieval_mode=1,
+            preset_id="balanced",
+            model_ids={"generator": "test-model"},
+            scope_key="scope",
+        ) is not None
+
+        documents._invalidate_query_caches_after_document_mutation()
+
+        assert memory_cache.get(
+            "What is the launch code?",
+            config_hash="cfg",
+            corpus_version="v1",
+            retrieval_mode=1,
+        ) is None
+        assert disk_cache.get(
+            "What is the launch code?",
+            corpus_version="v1",
+            retrieval_mode=1,
+            preset_id="balanced",
+            model_ids={"generator": "test-model"},
+            scope_key="scope",
+        ) is None
+    finally:
+        memory_cache.invalidate_all()
+        disk_cache.close()


### PR DESCRIPTION
### Motivation
- The query-result cache could return stale answers and snippets that include deleted document text because deletion endpoints rebuilt indexes but did not invalidate query caches.
- Cache keys previously did not change when documents were removed, which can violate deletion/retention expectations and leak sensitive content within the cache TTL.

### Description
- Add a helper ` _invalidate_query_caches_after_document_mutation()` in `api/app/routers/documents.py` that calls `get_cache_manager().queries.invalidate_all()` and `get_disk_query_cache().clear()` to drop in-memory and disk-backed query caches.
- Invoke the helper after `delete_document` and `delete_all_documents` complete their store/ACL/retrieval rebuild steps so query caches cannot serve deleted content.
- Add a regression test `test_document_mutation_invalidates_in_memory_and_disk_query_caches` in `api/tests/test_query_cache_security.py` which seeds both cache layers, calls the invalidation helper, and asserts both caches miss afterwards.

### Testing
- Ran the focused test file with the project virtualenv using `api/.venv/bin/python -m pytest api/tests/test_query_cache_security.py -q` and the suite completed successfully (`3 passed`).
- Attempting `python -m pytest api/tests/test_query_cache_security.py -q` under the system Python failed during collection due to missing external dependency `numpy` in that environment, which is unrelated to the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a370da04d108327af3e278dfe873e38)