### PR TITLE
Require admin scope for provider helper routes

### DIFF
--- a/api/app/core/security_middleware.py
+++ b/api/app/core/security_middleware.py
@@ -61,7 +61,7 @@ ROUTE_SCOPES = {
     "/config": "admin",
     "/experiments": "admin",
     "/evaluation": "read",
-    "/providers": "read",
+    "/providers": "admin",
     "/security": "read",
     "/install": "read",
     "/onboarding": "read",

--- a/api/tests/core/test_security_middleware.py
+++ b/api/tests/core/test_security_middleware.py
@@ -18,7 +18,7 @@ from app.core.security_middleware import _resolve_required_scope, verify_api_key
         ("/api/artifacts/graph", "GET", "read"),
         ("/api/cache/status", "GET", "read"),
         ("/api/metrics/presets/estimates", "GET", "read"),
-        ("/providers/local", "GET", "read"),
+        ("/providers/local", "GET", "admin"),
         ("/api/artifacts/build", "POST", "admin"),
         ("/api/cache/clear", "DELETE", "admin"),
         ("/api/cache/rebuild", "POST", "admin"),
@@ -28,6 +28,20 @@ from app.core.security_middleware import _resolve_required_scope, verify_api_key
 )
 def test_sensitive_protected_routes_resolve_expected_scopes(path: str, method: str, scope: str) -> None:
     assert _resolve_required_scope(path, method) == scope
+
+
+def test_provider_helpers_require_admin_scope_to_use_configured_credentials() -> None:
+    auth = APIKeyAuth(enabled=True)
+    read_key, _ = auth.generate_key("reader", scopes=["read"])
+    write_key, _ = auth.generate_key("writer", scopes=["write"])
+    admin_key, _ = auth.generate_key("admin", scopes=["admin"])
+
+    required_scope = _resolve_required_scope("/providers/openrouter/test", "POST")
+
+    assert required_scope == "admin"
+    assert not auth.verify(read_key, required_scope=required_scope)
+    assert not auth.verify(write_key, required_scope=required_scope)
+    assert auth.verify(admin_key, required_scope=required_scope)
 
 
 def test_evaluation_scope_resolution_is_method_specific() -> None:


### PR DESCRIPTION
### Motivation
- Close a confused-deputy authorization hole where provider helper endpoints could fall back to operator-stored cloud API keys when callers did not supply per-request credentials.  
- Prevent low-privilege (`read`/`write`) API keys from invoking `/providers` helper routes that may use configured operator credentials and quota.  

### Description
- Change the `/providers` route scope from `read` to `admin` in `api/app/core/security_middleware.py` by updating the `ROUTE_SCOPES` entry for `/providers` to `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a370f1a8f948327882521e94b733fdf)