### PR TITLE
Redact public readiness diagnostics

### DIFF
--- a/api/app/routers/health.py
+++ b/api/app/routers/health.py
@@ -10,7 +10,7 @@ import logging
 from fastapi import APIRouter, status
 from fastapi.responses import JSONResponse
 
-from ..schemas.health import ReadinessResponse
+from ..schemas.health import ReadinessCheck, ReadinessResponse
 from ..state import get_orchestrator
 
 logger = logging.getLogger("autorag.health")
@@ -24,18 +24,25 @@ def healthz() -> dict[str, str]:
     return {"status": "ok"}
 
 
+def _public_readiness_response(response: ReadinessResponse) -> ReadinessResponse:
+    """Strip operator-only diagnostics from the unauthenticated readiness response."""
+    return ReadinessResponse(
+        ready=response.ready,
+        level=response.level,
+        checks={
+            name: ReadinessCheck(status=check.status)
+            for name, check in response.checks.items()
+        },
+    )
+
+
 @router.get("/readyz", response_model=ReadinessResponse)
 def readyz() -> JSONResponse:
     """Readiness probe - is the service ready to accept traffic?
 
-    Checks:
-    - Orchestrator initialized
-    - Document store accessible
-    - Vector index loaded
-    - Embedding model available
-    - At least one LLM provider configured
-
-    Returns 200 if all checks pass, 503 if any critical check fails.
+    Returns a minimal public contract suitable for unauthenticated Kubernetes
+    and load-balancer probes. Detailed operator diagnostics are intentionally
+    omitted from this endpoint.
     """
     try:
         orchestrator = get_orchestrator()
@@ -43,27 +50,17 @@ def readyz() -> JSONResponse:
             response = ReadinessResponse(
                 ready=False,
                 level="not_ready",
-                checks={
-                    "orchestrator": {
-                        "status": "fail",
-                        "message": "Orchestrator not initialized",
-                        "details": {},
-                    }
-                },
+                checks={"orchestrator": ReadinessCheck(status="fail")},
             )
         else:
-            response = ReadinessResponse.model_validate(orchestrator.get_readiness_status())
-    except Exception as exc:
+            internal_response = ReadinessResponse.model_validate(orchestrator.get_readiness_status())
+            response = _public_readiness_response(internal_response)
+    except Exception:
+        logger.exception("Failed to build readiness report")
         response = ReadinessResponse(
             ready=False,
             level="not_ready",
-            checks={
-                "orchestrator": {
-                    "status": "fail",
-                    "message": f"Error building readiness report: {exc}",
-                    "details": {},
-                }
-            },
+            checks={"orchestrator": ReadinessCheck(status="fail")},
         )
 
     status_code = status.HTTP_200_OK if response.ready else status.HTTP_503_SERVICE_UNAVAILABLE

--- a/api/tests/api/test_endpoints.py
+++ b/api/tests/api/test_endpoints.py
@@ -172,8 +172,10 @@ def test_readyz_uses_runtime_status_contract(client: TestClient) -> None:
     assert body["ready"] is True
     assert body["level"] in {"ready", "degraded"}
     assert body["checks"]["orchestrator"]["status"] == "ok"
-    assert body["checks"]["document_store"]["details"]["document_count"] == 0
+    assert body["checks"]["document_store"]["details"] == {}
+    assert body["checks"]["document_store"]["message"] is None
     assert body["checks"]["retrieval_index"]["status"] == "ok"
+    assert body["checks"]["retrieval_index"]["details"] == {}
 
 
 def test_readyz_returns_503_without_orchestrator(client: TestClient) -> None:
@@ -190,6 +192,8 @@ def test_readyz_returns_503_without_orchestrator(client: TestClient) -> None:
     assert body["ready"] is False
     assert body["level"] == "not_ready"
     assert body["checks"]["orchestrator"]["status"] == "fail"
+    assert body["checks"]["orchestrator"]["message"] is None
+    assert body["checks"]["orchestrator"]["details"] == {}
 
 
 def test_security_posture_reports_local_install_defaults(client: TestClient) -> None:


### PR DESCRIPTION
### Motivation
- The unauthenticated `/readyz` endpoint exposed operator-only diagnostics, raw exception messages, and backend details that could be used for fingerprinting and information disclosure. 
- The goal is to limit the public readiness contract to what Kubernetes/load-balancers need (ready/level/check status) while keeping detailed diagnostics available to operators internally.

### Description
- Added `_public_readiness_response` to transform an internal `ReadinessResponse` into a redacted `ReadinessResponse` that only includes per-check `status` via `ReadinessCheck` and omits `message`/`details` and model/provider names. 
- Updated the `/readyz` handler to build the internal readiness report with `orchestrator.get_readiness_status()`, then return the redacted public response, and to log and return a generic failed payload if readiness construction raises. 
- Replaced explicit diagnostic payloads in failure paths with minimal `ReadinessCheck(status="fail")` objects so unauthenticated callers cannot see raw exceptions. 
- Updated tests in `api/tests/api/test_endpoints.py` to assert that public readiness responses have empty `details` and no `message` fields for the tested checks.

### Testing
- Ran the targeted readiness tests with `cd api && uv run pytest tests/api/test_endpoints.py::test_readyz_uses_runtime_status_contract tests/api/test_endpoints.py::test_readyz_returns_503_without_orchestrator -q`, and both tests passed (`2 passed`).
- Compiled the modified module with `python -m compileall api/app/routers/health.py`, which succeeded without errors. 
- Executed the full endpoint test file with `cd api && uv run pytest tests/api/test_endpoints.py -q`, which exhibited one unrelated environment-dependent failure (`test_document_ingest_query_and_evaluation`) due to missing dense-retrieval dependencies (`sentence-transformers not installed`), while other tests passed (30 passed, 1 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a370f1d3df883279664bfb9014f952c)