### PR TITLE
Enforce ACLs for onboarding demo seed/clear endpoints

### DIFF
--- a/api/app/routers/onboarding.py
+++ b/api/app/routers/onboarding.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 
 from ..core.auth import get_auth
 from ..core.document_acl import get_acl_enforcer, get_acl_store, resolve_acl_defaults
@@ -30,6 +30,21 @@ def _create_acl(document_id: str, request: Request) -> None:
     if enforcer.store.get(document_id) is None:
         public = new_doc_public if (auth_enabled and user_id) else True
         enforcer.create_acl_for_document(document_id, owner=user_id or "anonymous", public=public)
+
+
+def _ensure_document_write_access(document_id: str, request: Request) -> None:
+    auth_enabled = get_auth().require_auth()
+    if not auth_enabled:
+        return
+    scopes = getattr(request.state, "scopes", [])
+    if "admin" in scopes:
+        return
+    default_public, _ = resolve_acl_defaults(auth_enabled)
+    enforcer = get_acl_enforcer(default_public=default_public)
+    user_id = getattr(request.state, "user_id", None)
+    allowed, _ = enforcer.check_access(document_id, user_id, "write")
+    if not allowed:
+        raise HTTPException(status_code=403, detail="Insufficient permissions to update this document")
 
 
 @router.get("")
@@ -68,6 +83,7 @@ def seed_demo_corpus(
         title = str(item["title"])
         existing = container.document_store.get_by_title(title)
         if existing:
+            _ensure_document_write_access(existing.id, request)
             existing.metadata.update(_demo_metadata(list(item.get("tags", [])), index))
             container.document_store.upsert(existing)
             _create_acl(existing.id, request)
@@ -93,14 +109,23 @@ def seed_demo_corpus(
 
 
 @router.delete("/demo")
-def clear_demo_corpus(container: ServiceContainer = Depends(get_container)) -> dict:
+def clear_demo_corpus(
+    request: Request,
+    container: ServiceContainer = Depends(get_container),
+) -> dict:
     """Remove only demo-tagged documents."""
+    demo_docs = [
+        doc for doc in list(container.document_store.list())
+        if doc.metadata.get("demo_corpus") == "true"
+    ]
+    for doc in demo_docs:
+        _ensure_document_write_access(doc.id, request)
+
     deleted = 0
-    for doc in list(container.document_store.list()):
-        if doc.metadata.get("demo_corpus") == "true":
-            container.document_store.delete(doc.id)
-            get_acl_store().delete(doc.id)
-            deleted += 1
+    for doc in demo_docs:
+        container.document_store.delete(doc.id)
+        get_acl_store().delete(doc.id)
+        deleted += 1
     if deleted:
         container.retrieval_engine.build()
     return {"deleted": deleted, "document_count": len(container.document_store.list())}

--- a/api/tests/api/test_endpoints.py
+++ b/api/tests/api/test_endpoints.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import hashlib
 import tempfile
 from pathlib import Path
 
@@ -11,6 +12,8 @@ from fastapi.testclient import TestClient
 
 from app.core import auth as auth_module
 from app.core.auth import APIKeyAuth
+from app.core.document_acl import DocumentACL, get_acl_store
+from app.core.documents import Document
 from app.core.golden_eval import AnswerMetrics, EvalRunResult, EvalRunStore, GoldenSetStore, RetrievalMetrics
 from app.main import app
 from app.routers import config as config_router
@@ -501,6 +504,71 @@ def test_onboarding_demo_mutations_require_write_scope(
     clear_allowed = client.delete("/onboarding/demo", headers=write_headers)
     assert clear_allowed.status_code == 200
     assert clear_allowed.json()["deleted"] > 0
+
+
+def test_onboarding_demo_respects_document_write_acl(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    auth = APIKeyAuth(enabled=True)
+    write_key, _ = auth.generate_key("writer", scopes=["write"])
+    monkeypatch.setattr(auth_module, "_auth_instance", auth)
+    get_acl_store().clear()
+
+    container = app.dependency_overrides[get_container]()
+    protected_doc = Document(
+        id="protected-demo-title",
+        title="JR AutoRAG Evaluation Brief",
+        text="Private admin-owned content",
+        metadata={"demo_corpus": "false"},
+    )
+    container.document_store.upsert(protected_doc)
+    get_acl_store().set(DocumentACL.create_private(protected_doc.id, owner="admin-user"))
+
+    response = client.post("/onboarding/demo/seed", headers={"X-API-Key": write_key})
+
+    assert response.status_code == 403
+    assert container.document_store.get(protected_doc.id).metadata["demo_corpus"] == "false"
+
+    writer_id = hashlib.sha256(write_key.encode()).hexdigest()[:16]
+    get_acl_store().set(DocumentACL.create_private(protected_doc.id, owner=writer_id))
+
+    allowed = client.post("/onboarding/demo/seed", headers={"X-API-Key": write_key})
+
+    assert allowed.status_code == 200
+    assert container.document_store.get(protected_doc.id).metadata["demo_corpus"] == "true"
+
+
+def test_onboarding_demo_clear_respects_document_write_acl(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    auth = APIKeyAuth(enabled=True)
+    write_key, _ = auth.generate_key("writer", scopes=["write"])
+    monkeypatch.setattr(auth_module, "_auth_instance", auth)
+    get_acl_store().clear()
+
+    container = app.dependency_overrides[get_container]()
+    protected_doc = Document(
+        id="protected-demo-doc",
+        title="Protected Demo",
+        text="Private demo-tagged content",
+        metadata={"demo_corpus": "true"},
+    )
+    container.document_store.upsert(protected_doc)
+    get_acl_store().set(DocumentACL.create_private(protected_doc.id, owner="admin-user"))
+
+    response = client.delete("/onboarding/demo", headers={"X-API-Key": write_key})
+
+    assert response.status_code == 403
+    assert container.document_store.get(protected_doc.id) is not None
+
+    writer_id = hashlib.sha256(write_key.encode()).hexdigest()[:16]
+    get_acl_store().set(DocumentACL.create_private(protected_doc.id, owner=writer_id))
+
+    allowed = client.delete("/onboarding/demo", headers={"X-API-Key": write_key})
+
+    assert allowed.status_code == 200
+    assert allowed.json()["deleted"] == 1
+    assert container.document_store.get(protected_doc.id) is None
 
 
 def test_onboarding_demo_seed_query_and_clear(client: TestClient) -> None:


### PR DESCRIPTION
### Motivation
- Prevent lower-privileged API keys from mutating or deleting documents via the onboarding demo endpoints by requiring per-document write permission before any metadata update or deletion.
- Avoid title-collision updates that mark existing private documents as demo data without verifying document ownership or write ACLs.

### Description
- Add `_ensure_document_write_access(document_id, request)` to `api/app/routers/onboarding.py` which enforces per-document write ACLs and raises `HTTPException(403)` when access is denied.
- Apply the ACL check in `POST /onboarding/demo/seed` before updating an existing document found by title to prevent unauthorized title-collision updates.
- Change `DELETE /onboarding/demo` to first collect demo-tagged documents, verify write access for each using the new checker, then perform deletions only for allowed documents.
- Add regression tests in `api/tests/api/test_endpoints.py` that assert the seed and clear demo flows respect document write ACLs and deny/allow actions based on ACL ownership.

### Testing
- Static parsing checks passed via `ast.parse()` on the modified files and `python -m py_compile` for the test module, both succeeding.
- Repository style/format checks passed via `git diff --check` with no warnings.
- Attempted to run the integration tests with `pytest api/tests/api/test_endpoints.py -q`, but the test run failed in this environment due to missing test dependencies (`ModuleNotFoundError: No module named 'fastapi'`), so the new tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a370f1a7f548327874d2faec46076dd)