### PR TITLE
Fix LangExtract timeout worker cleanup

### DIFF
--- a/api/app/core/langextract_enricher.py
+++ b/api/app/core/langextract_enricher.py
@@ -341,13 +341,17 @@ class LangExtractEnricher:
     def _run_with_timeout(self, fn: Any, timeout: int) -> Any:
         executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="langextract")
         future = executor.submit(fn)
+        shutdown_complete = False
         try:
             return future.result(timeout=timeout)
         except FutureTimeoutError as exc:
-            future.cancel()
+            if not future.cancel():
+                executor.shutdown(wait=True, cancel_futures=True)
+                shutdown_complete = True
             raise TimeoutError(f"LangExtract timed out after {timeout}s") from exc
         finally:
-            executor.shutdown(wait=False, cancel_futures=True)
+            if not shutdown_complete:
+                executor.shutdown(wait=True, cancel_futures=True)
 
     def _normalize_attributes(self, attributes: Any) -> dict[str, str]:
         if not isinstance(attributes, dict):

--- a/api/tests/test_langextract_enricher.py
+++ b/api/tests/test_langextract_enricher.py
@@ -97,19 +97,20 @@ def test_synthetic_sections_are_deterministic_and_capped() -> None:
     assert "## LangExtract Entities" in rendered
 
 
-def test_run_with_timeout_returns_without_waiting_for_worker_completion(tmp_path: Path) -> None:
+def test_run_with_timeout_waits_for_running_worker_after_timeout(tmp_path: Path) -> None:
     enricher = LangExtractEnricher(data_dir=tmp_path)
 
     def slow_extract() -> None:
-        time.sleep(2)
+        time.sleep(0.2)
 
     started = time.monotonic()
     try:
-        enricher._run_with_timeout(slow_extract, timeout=1)
+        enricher._run_with_timeout(slow_extract, timeout=0.01)
     except TimeoutError as exc:
         elapsed = time.monotonic() - started
-        assert "LangExtract timed out after 1s" in str(exc)
-        assert elapsed < 1.5
+        assert "LangExtract timed out after 0.01s" in str(exc)
+        assert elapsed >= 0.2
+        assert elapsed < 1.0
     else:  # pragma: no cover - defensive assertion
         raise AssertionError("expected LangExtract timeout")
 


### PR DESCRIPTION
### Motivation
- Prevent timed-out LangExtract calls from leaving active worker threads running in the background, which can accumulate and exhaust local or provider resources.
- Restore deterministic fail-open behavior where a timeout is reported but the active worker is allowed to finish rather than being orphaned.

### Description
- Change `_run_with_timeout` to attempt `future.cancel()` and, if cancellation fails, call `executor.shutdown(wait=True, cancel_futures=True)` so the active worker is awaited instead of left running in background.
- Ensure the executor is always shut down with `wait=True` unless shutdown was already performed after a failed cancel attempt, by introducing a `shutdown_complete` flag.
- Update the timeout regression test (`test_run_with_timeout_waits_for_running_worker_after_timeout`) to assert that `_run_with_timeout` waits for a running worker to finish when cancellation cannot stop it, using a short sleep and a sub-second timeout.

### Testing
- Ran `uv run pytest tests/test_langextract_enricher.py -q` and all tests passed (`6 passed`).
- Ran `uv run ruff check app/core/langextract_enricher.py tests/test_langextract_enricher.py` and lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a370f1abfd083279f1afc592e6c1a4b)