### PR TITLE
Restore durable RAGFuzz audit writes

### DIFF
--- a/api/app/routers/ragfuzz_audit.py
+++ b/api/app/routers/ragfuzz_audit.py
@@ -20,7 +20,7 @@ import uuid
 from datetime import UTC, datetime
 from typing import Any
 
-from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException
 from pydantic import BaseModel, Field
 
 from ..core.audit import AuditAction, AuditEntry, get_audit_log
@@ -172,7 +172,6 @@ async def ragfuzz_health(
 @router.post("/poison", response_model=PoisonDocumentResponse)
 async def inject_poison_document(
     request: PoisonDocumentRequest,
-    background_tasks: BackgroundTasks,
     container: ServiceContainer = Depends(get_container),
     _: None = Depends(_verify_ragfuzz_secret),
 ) -> PoisonDocumentResponse:
@@ -208,8 +207,7 @@ async def inject_poison_document(
         raise HTTPException(status_code=500, detail=f"Failed to inject document: {exc}") from exc
 
     audit_log = get_audit_log()
-    background_tasks.add_task(
-        audit_log.log,
+    audit_log.log(
         AuditEntry(
             timestamp=datetime.now(UTC),
             action=AuditAction.INGEST,
@@ -233,7 +231,6 @@ async def inject_poison_document(
 @router.post("/canary-check", response_model=CanaryCheckResponse)
 async def check_canary_leak(
     request: CanaryCheckRequest,
-    background_tasks: BackgroundTasks,
     container: ServiceContainer = Depends(get_container),
     _: None = Depends(_verify_ragfuzz_secret),
 ) -> CanaryCheckResponse:
@@ -272,8 +269,7 @@ async def check_canary_leak(
         leak_score = partial_matches / max(len(canary_parts), 1) * 0.5
 
     audit_log = get_audit_log()
-    background_tasks.add_task(
-        audit_log.log,
+    audit_log.log(
         AuditEntry(
             timestamp=datetime.now(UTC),
             action=AuditAction.QUERY,
@@ -359,7 +355,6 @@ async def trace_pipeline(
 @router.delete("/poison/{document_id}")
 async def remove_poison_document(
     document_id: str,
-    background_tasks: BackgroundTasks,
     container: ServiceContainer = Depends(get_container),
     _: None = Depends(_verify_ragfuzz_secret),
 ) -> dict[str, str]:
@@ -373,8 +368,7 @@ async def remove_poison_document(
         raise HTTPException(status_code=500, detail=f"Failed to remove document: {exc}") from exc
 
     audit_log = get_audit_log()
-    background_tasks.add_task(
-        audit_log.log,
+    audit_log.log(
         AuditEntry(
             timestamp=datetime.now(UTC),
             action=AuditAction.DELETE,

--- a/api/tests/test_ragfuzz_audit.py
+++ b/api/tests/test_ragfuzz_audit.py
@@ -1,0 +1,86 @@
+"""Regression tests for durable RAGFuzz audit logging."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.routers import ragfuzz_audit
+
+
+class FakeOrchestrator:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, object]] = []
+
+    async def ingest(self, **kwargs: object) -> None:
+        self.calls.append(("ingest", kwargs))
+
+    async def answer(self, query: str, document_ids: list[str] | None = None) -> dict[str, str]:
+        self.calls.append(("answer", {"query": query, "document_ids": document_ids}))
+        return {"answer": "response with CANARY_TEST_TOKEN"}
+
+    async def delete_document(self, document_id: str) -> None:
+        self.calls.append(("delete", document_id))
+
+
+class FakeContainer:
+    def __init__(self) -> None:
+        self.orchestrator = FakeOrchestrator()
+
+
+class FailingAuditLog:
+    def __init__(self) -> None:
+        self.entries: list[object] = []
+
+    def log(self, entry: object) -> None:
+        self.entries.append(entry)
+        raise OSError("audit write failed")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("endpoint", "payload", "expected_call"),
+    [
+        (
+            ragfuzz_audit.inject_poison_document,
+            ragfuzz_audit.PoisonDocumentRequest(content="poison", canary_token="CANARY_TEST_TOKEN"),
+            "ingest",
+        ),
+        (
+            ragfuzz_audit.check_canary_leak,
+            ragfuzz_audit.CanaryCheckRequest(query="check", canary_token="CANARY_TEST_TOKEN"),
+            "answer",
+        ),
+    ],
+)
+async def test_ragfuzz_audit_write_failure_prevents_success_response(
+    monkeypatch: pytest.MonkeyPatch,
+    endpoint: object,
+    payload: object,
+    expected_call: str,
+) -> None:
+    """Sensitive RAGFuzz endpoints must not return success before the audit write finishes."""
+    audit_log = FailingAuditLog()
+    container = FakeContainer()
+    monkeypatch.setattr(ragfuzz_audit, "get_audit_log", lambda: audit_log)
+
+    with pytest.raises(OSError, match="audit write failed"):
+        await endpoint(request=payload, container=container)
+
+    assert container.orchestrator.calls[0][0] == expected_call
+    assert len(audit_log.entries) == 1
+
+
+@pytest.mark.asyncio
+async def test_ragfuzz_delete_audit_write_failure_prevents_success_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Poison deletion must not return success before the audit delete entry is durable."""
+    audit_log = FailingAuditLog()
+    container = FakeContainer()
+    monkeypatch.setattr(ragfuzz_audit, "get_audit_log", lambda: audit_log)
+
+    with pytest.raises(OSError, match="audit write failed"):
+        await ragfuzz_audit.remove_poison_document("poison_doc", container=container)
+
+    assert container.orchestrator.calls == [("delete", "poison_doc")]
+    assert len(audit_log.entries) == 1


### PR DESCRIPTION
### Motivation
- Recent change deferred audit writes for RAGFuzz endpoints into FastAPI `BackgroundTasks`, causing a window where sensitive operations (poison ingest, canary-check, delete) could succeed while their audit entries might never be persisted.
- This weakens accountability for security-testing endpoints where durable audit records are required and should be recorded before returning success.

### Description
- Replaced post-response `BackgroundTasks` usage with synchronous calls to `audit_log.log(...)` in the RAGFuzz endpoints at `api/app/routers/ragfuzz_audit.py` for poison injection, canary check, and poison deletion so audit writes occur before returning.
- Removed the `BackgroundTasks` import and endpoint parameters that previously queued audit writes and restored immediate durable writes via `get_audit_log().log(...)`.
- Added regression tests at `api/tests/test_ragfuzz_audit.py` that simulate an audit write failure and assert the endpoints do not return success before the audit write completes and raises.

### Testing
- Ran the new regression test suite with `cd api && uv run pytest tests/test_ragfuzz_audit.py`, and all tests passed (`3 passed`).
- Ran linting with `cd api && uv run ruff check app/routers/ragfuzz_audit.py tests/test_ragfuzz_audit.py`, and checks passed.
- Ran repository diff/format checks (`git diff --check`) with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a384dc152c88327b8e277b59bb52927)