### PR TITLE
Fix LangExtract timeout shutdown

### DIFF
--- a/api/app/core/langextract_enricher.py
+++ b/api/app/core/langextract_enricher.py
@@ -341,16 +341,16 @@ class LangExtractEnricher:
     def _run_with_timeout(self, fn: Any, timeout: int) -> Any:
         executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="langextract")
         future = executor.submit(fn)
-        shutdown_complete = False
+        timed_out = False
         try:
             return future.result(timeout=timeout)
         except FutureTimeoutError as exc:
-            if not future.cancel():
-                executor.shutdown(wait=True, cancel_futures=True)
-                shutdown_complete = True
+            timed_out = True
+            future.cancel()
+            executor.shutdown(wait=False, cancel_futures=True)
             raise TimeoutError(f"LangExtract timed out after {timeout}s") from exc
         finally:
-            if not shutdown_complete:
+            if not timed_out:
                 executor.shutdown(wait=True, cancel_futures=True)
 
     def _normalize_attributes(self, attributes: Any) -> dict[str, str]:

--- a/api/tests/test_langextract_enricher.py
+++ b/api/tests/test_langextract_enricher.py
@@ -97,7 +97,7 @@ def test_synthetic_sections_are_deterministic_and_capped() -> None:
     assert "## LangExtract Entities" in rendered
 
 
-def test_run_with_timeout_waits_for_running_worker_after_timeout(tmp_path: Path) -> None:
+def test_run_with_timeout_returns_promptly_after_timeout(tmp_path: Path) -> None:
     enricher = LangExtractEnricher(data_dir=tmp_path)
 
     def slow_extract() -> None:
@@ -109,10 +109,10 @@ def test_run_with_timeout_waits_for_running_worker_after_timeout(tmp_path: Path)
     except TimeoutError as exc:
         elapsed = time.monotonic() - started
         assert "LangExtract timed out after 0.01s" in str(exc)
-        assert elapsed >= 0.2
-        assert elapsed < 1.0
+        assert elapsed < 0.1
     else:  # pragma: no cover - defensive assertion
         raise AssertionError("expected LangExtract timeout")
+
 
 def test_ingest_fail_open_when_extraction_fails(tmp_path: Path) -> None:
     store = DocumentStore(path=tmp_path / "docs.db")


### PR DESCRIPTION
### Motivation
- Prevent request-handling from blocking indefinitely when a LangExtract provider call hangs by preserving the configured timeout as a latency bound.
- Ensure ingestion remains resilient and does not allow a remote client to tie up API worker capacity via a stalled extraction.

### Description
- Change `_run_with_timeout` to cancel the running future and call `executor.shutdown(wait=False, cancel_futures=True)` on timeout so the wrapper returns promptly while the worker may continue in the background.
- Keep the original blocking `shutdown(wait=True, cancel_futures=True)` behavior for the normal non-timeout cleanup path so executor resources are still released when work completes.
- Add a `timed_out` flag to distinguish timeout cleanup from normal shutdown and call `future.cancel()` before the non-blocking shutdown.
- Update the timeout regression test in `api/tests/test_langextract_enricher.py` to assert the wrapper returns promptly after the configured timeout instead of waiting for the slow worker to finish.

### Testing
- Ran linter checks with `cd api && uv run ruff check app/core/langextract_enricher.py tests/test_langextract_enricher.py`, which passed.
- Executed unit tests with `cd api && uv run pytest tests/test_langextract_enricher.py`, resulting in all tests passing (`6 passed`).
- A direct `pytest api/tests/test_langextract_enricher.py` run initially errored during collection due to a missing optional dependency (`numpy`), but the targeted test run under the project environment succeeded as noted above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a384f270b3083279e5e62f5d146b9d4)