### PR TITLE
fix(api): repair sparse/BM25 retrieval so API CI passes without dense embeddings

### DIFF
--- a/api/app/core/hybrid_retrieval.py
+++ b/api/app/core/hybrid_retrieval.py
@@ -394,8 +394,17 @@ class HybridRetrievalEngine:
         return False
 
     def _tokenize(self, text: str) -> list[str]:
-        """Simple tokenization for BM25."""
-        return text.lower().split()
+        """Tokenize text for BM25 and sparse matching.
+
+        Splits on non-alphanumeric boundaries so punctuation does not stay
+        attached to terms. Without this, a query like "What is AutoRAG?"
+        tokenizes the final term as "autorag?" and fails to match the indexed
+        corpus token "autorag", which silently breaks BM25/sparse retrieval
+        when dense (sentence-transformers) retrieval is unavailable. The same
+        tokenizer is used for both corpus indexing and query parsing, so
+        normalizing here keeps the two sides aligned.
+        """
+        return [t for t in re.findall(r"[a-z0-9]+", text.lower()) if t]
 
     def _tokenize_terms(self, text: str) -> list[str]:
         """Tokenize text into alphanumeric terms for scoring boosts."""


### PR DESCRIPTION
## Summary

Fixes the failing **API (Python)** CI job. The failing test is
`tests/api/test_endpoints.py::test_document_ingest_query_and_evaluation`,
which ingests a document, queries it, and asserts `query_data["chunks"]` is
non-empty — but it received `[]`.

## Root cause

The API CI job installs deps with `uv sync --locked --all-groups`. This
installs dependency *groups* (`dev`) but **not** the optional `ml` extra
(`sentence-transformers` + `torch`). Running without dense embeddings is an
**intended, supported local-first config** — `rank-bm25` is a core dependency
and the BM25/sparse path is the designed fallback.

The real bug is in `HybridRetrievalEngine._tokenize`, which used a naive
`text.lower().split()`. That leaves punctuation attached to terms. The query
`"What is JR AutoRAG?"` tokenized its only content term as `autorag?`, which
never matches the indexed corpus token `autorag`. For the test's
single-document corpus this:

- drove the BM25 score negative (then dropped by the `score <= 0` filter in `_sparse_search`), and
- broke `_literal_search` token matching (`autorag?` not found in text),

so retrieval returned nothing. Dense retrieval previously **masked** this by
matching semantically; with `sentence-transformers` absent in CI, the bug
surfaced. Because the same `_tokenize` is used for **both** corpus indexing
and query parsing, the mismatch silently degraded *all* sparse retrieval, not
just this test.

Larger-corpus tests (`test_onboarding_demo_seed_query_and_clear`,
`test_demo_seed_supports_client_readiness_benchmark`) kept passing only
because other query terms matched enough chunks to score positive — they
masked the same latent defect.

## Approach chosen — and why

Two options were considered:

1. Install the `ml` extra (sentence-transformers + torch) in CI.
2. Make the supported sparse path actually work (fix the real regression).

**Chosen: option 2.** Running without sentence-transformers is a supported
configuration, the sparse path *should* return chunks, and the empty result
was a genuine tokenization bug — not a missing dependency. Option 1 was
rejected: no CI job installs the heavy `ml` extra anywhere, the API job has a
10-minute timeout, and pulling `torch` would be a large, slow, inconsistent
addition that would also hide rather than fix the underlying sparse-retrieval
defect.

The assertion was **not** weakened or skipped — the test now passes because
real evidence is retrieved.

## Fix

Tokenize on alphanumeric boundaries, matching the existing `_tokenize_terms`
convention:

```python
return [t for t in re.findall(r"[a-z0-9]+", text.lower()) if t]
```

Corpus and query tokens now align (`autorag?` → `autorag` matches `autorag`).

## Verification (run via uv, matching CI)

- `uv run pytest tests/api/test_endpoints.py::test_document_ingest_query_and_evaluation` → **PASSED**, and for a real reason: direct engine query now returns evidence chunks instead of `[]`.
- `uv run pytest tests/ -v --tb=short --ignore=tests/__pycache__ -x --timeout=60` (exact CI push command) → **283 passed**, no regressions.
- `uv run ruff check . --select F821,F811,E9` → clean.
- `uv run python -c "from app.main import app; print('API imports OK')"` → OK.

No new dependencies added; `torch` is intentionally not pulled into CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)