### PR TITLE
🧹 Remove unused annotation import in langextract_enricher.py

### DIFF
--- a/api/app/core/langextract_enricher.py
+++ b/api/app/core/langextract_enricher.py
@@ -1,6 +1,5 @@
 """LangExtract adapter for optional ingestion-time enrichment."""
 
-from __future__ import annotations
 
 import json
 from concurrent.futures import ThreadPoolExecutor


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` import in `api/app/core/langextract_enricher.py`.
💡 **Why:** Improves maintainability and readability by removing a single unused import.
✅ **Verification:** Ran `ruff check` and `pytest` suite, verified no regressions and safe refactoring.
✨ **Result:** Clean code state with no functionality change.

---
*PR created automatically by Jules for task [4859005780615365241](https://jules.google.com/task/4859005780615365241) started by @JonathanRReed*