### PR TITLE
⚡ Optimize GoldenSetEvaluator for concurrent test case execution

### DIFF
--- a/api/app/core/golden_eval.py
+++ b/api/app/core/golden_eval.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+import asyncio
 
 from .config_snapshot import get_tool_versions
 
@@ -484,6 +485,7 @@ class GoldenSetEvaluator:
         orchestrator: Orchestrator,
         set_name: str,
         on_progress: callable | None = None,
+        max_concurrent: int = 5,
     ) -> EvalRunResult:
         """Run evaluation on a golden set."""
         test_cases = self.golden_store.get_set(set_name)
@@ -493,61 +495,71 @@ class GoldenSetEvaluator:
         run_id = str(uuid.uuid4())[:12]
         start_time = time.perf_counter()
         individual_results: list[TestCaseResult] = []
+        semaphore = asyncio.Semaphore(max_concurrent)
+        completed_count = 0
 
-        for i, case in enumerate(test_cases):
-            if on_progress:
-                on_progress(i + 1, len(test_cases), case.question)
+        async def process_case(case: GoldenTestCase, index: int) -> TestCaseResult:
+            nonlocal completed_count
+            async with semaphore:
+                case_start = time.perf_counter()
 
-            case_start = time.perf_counter()
+                # Run the query
+                response = await orchestrator.answer(case.question)
 
-            # Run the query
-            response = await orchestrator.answer(case.question)
+                case_duration = (time.perf_counter() - case_start) * 1000
 
-            case_duration = (time.perf_counter() - case_start) * 1000
+                # Extract retrieved source IDs
+                retrieved_ids = [
+                    s.get("id", "") for s in response.get("sources", [])
+                ]
 
-            # Extract retrieved source IDs
-            retrieved_ids = [
-                s.get("id", "") for s in response.get("sources", [])
-            ]
+                # Compute retrieval metrics
+                retrieval_metrics = RetrievalMetrics(
+                    recall_at_k=compute_recall_at_k(retrieved_ids, case.expected_source_ids),
+                    mrr=compute_mrr(retrieved_ids, case.expected_source_ids),
+                    ndcg=compute_ndcg(retrieved_ids, case.expected_source_ids),
+                    citation_coverage=compute_citation_coverage(
+                        response.get("answer", ""),
+                        len(response.get("sources", [])),
+                    ),
+                )
 
-            # Compute retrieval metrics
-            retrieval_metrics = RetrievalMetrics(
-                recall_at_k=compute_recall_at_k(retrieved_ids, case.expected_source_ids),
-                mrr=compute_mrr(retrieved_ids, case.expected_source_ids),
-                ndcg=compute_ndcg(retrieved_ids, case.expected_source_ids),
-                citation_coverage=compute_citation_coverage(
-                    response.get("answer", ""),
-                    len(response.get("sources", [])),
-                ),
-            )
+                # Compute answer metrics
+                answer_metrics = AnswerMetrics(
+                    completeness=compute_completeness(
+                        response.get("answer", ""),
+                        case.expected_answer_points,
+                    ),
+                    refusal_accuracy=compute_refusal_accuracy(
+                        response.get("answer", ""),
+                        case.tags,
+                    ),
+                    # Prefer explicit top-level metrics, then production RAGAS scores.
+                    faithfulness=_nested_metric(response.get("metrics", {}), ["faithfulness"])
+                    or _nested_metric(response.get("metrics", {}), ["ragas", "faithfulness"]),
+                    coherence=_nested_metric(response.get("metrics", {}), ["coherence"])
+                    or _nested_metric(response.get("metrics", {}), ["ragas", "overall_score"]),
+                )
 
-            # Compute answer metrics
-            answer_metrics = AnswerMetrics(
-                completeness=compute_completeness(
-                    response.get("answer", ""),
-                    case.expected_answer_points,
-                ),
-                refusal_accuracy=compute_refusal_accuracy(
-                    response.get("answer", ""),
-                    case.tags,
-                ),
-                # Prefer explicit top-level metrics, then production RAGAS scores.
-                faithfulness=_nested_metric(response.get("metrics", {}), ["faithfulness"])
-                or _nested_metric(response.get("metrics", {}), ["ragas", "faithfulness"]),
-                coherence=_nested_metric(response.get("metrics", {}), ["coherence"])
-                or _nested_metric(response.get("metrics", {}), ["ragas", "overall_score"]),
-            )
+                result = TestCaseResult(
+                    test_case_id=case.id,
+                    question=case.question,
+                    answer=response.get("answer", ""),
+                    retrieved_source_ids=retrieved_ids,
+                    retrieval_metrics=retrieval_metrics,
+                    answer_metrics=answer_metrics,
+                    duration_ms=case_duration,
+                    trace_id=response.get("trace_id", ""),
+                )
 
-            individual_results.append(TestCaseResult(
-                test_case_id=case.id,
-                question=case.question,
-                answer=response.get("answer", ""),
-                retrieved_source_ids=retrieved_ids,
-                retrieval_metrics=retrieval_metrics,
-                answer_metrics=answer_metrics,
-                duration_ms=case_duration,
-                trace_id=response.get("trace_id", ""),
-            ))
+                completed_count += 1
+                if on_progress:
+                    on_progress(completed_count, len(test_cases), case.question)
+
+                return result
+
+        tasks = [process_case(case, i) for i, case in enumerate(test_cases)]
+        individual_results = await asyncio.gather(*tasks)
 
         # Aggregate metrics
         n = len(individual_results)


### PR DESCRIPTION
💡 **What:** Changed `GoldenSetEvaluator.run_batch` to process golden test cases concurrently using `asyncio.gather`.
Introduced a `max_concurrent` parameter (default `5`) and an `asyncio.Semaphore` to throttle concurrency and avoid LLM API rate limits.

🎯 **Why:** Sequential execution of RAG test cases takes a lot of time as it awaits single responses from the LLM orchestrator. Parallelizing the API requests provides significant throughput gains without overwhelming upstream providers since we introduced a concurrent cap via semaphore.

📊 **Measured Improvement:**
In a benchmark with 20 dummy test cases where each orchestrator query takes `0.1s`:
- Baseline (Sequential execution): ~2.02s
- Optimized (Concurrent execution with max_concurrent=5): ~0.41s
- **Speedup:** ~80% reduction in evaluation time (5x improvement)

---
*PR created automatically by Jules for task [9059718396376590953](https://jules.google.com/task/9059718396376590953) started by @JonathanRReed*