### PR TITLE
⚡ Evaluate test cases concurrently in eval_harness

### DIFF
--- a/api/app/core/eval_harness.py
+++ b/api/app/core/eval_harness.py
@@ -8,6 +8,8 @@ This module implements P2.12: Evaluation Harness
 
 from __future__ import annotations
 
+import asyncio
+
 import json
 import logging
 import time
@@ -217,9 +219,11 @@ class EvalHarness:
             config_snapshot=config or {},
         )
 
-        for case in cases:
-            result = await self._evaluate_case(case)
-            run.results.append(result)
+        # Run evaluation on all cases concurrently
+        results = await asyncio.gather(
+            *(self._evaluate_case(case) for case in cases)
+        )
+        run.results.extend(results)
 
         self._runs[run_id] = run
         self._save_run(run)

--- a/api/benchmark_eval_harness.py
+++ b/api/benchmark_eval_harness.py
@@ -1,0 +1,29 @@
+import asyncio
+import time
+from pathlib import Path
+from app.core.eval_harness import EvalHarness, EvalCase
+
+async def dummy_query_fn(query: str):
+    await asyncio.sleep(0.1)
+    return {
+        "answer": f"Answer to {query}",
+        "chunks": [{"title": "Source 1"}],
+        "metrics": {"tokens": 10},
+        "grounding": {"grounded": True}
+    }
+
+async def main():
+    harness = EvalHarness(data_path=Path("/tmp/eval_data"), query_fn=dummy_query_fn)
+    cases = [
+        EvalCase(id=f"case_{i}", query=f"Query {i}", expected_answer="Expected")
+        for i in range(20)
+    ]
+
+    start_time = time.time()
+    await harness.run(cases)
+    end_time = time.time()
+
+    print(f"Elapsed time for 20 cases: {end_time - start_time:.2f}s")
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
💡 **What:** The evaluation loop in `api/app/core/eval_harness.py` was modified to execute cases concurrently using `asyncio.gather()` rather than sequentially iterating through the list of eval cases and running them one by one.

🎯 **Why:** The previous code ran `self._evaluate_case(case)` on each item in `cases` in a sequential `for` loop. Since these evaluation requests are completely independent of each other and involve async IO tasks (network requests and waiting), executing them serially underutilizes system resources and vastly increases the time needed to evaluate many cases. Utilizing Python's `asyncio.gather()` executes these requests concurrently, which substantially decreases the evaluation time without compromising correctness.

📊 **Measured Improvement:**
A local benchmark was created simulating twenty test cases with an artificial `dummy_query_fn` async operation introducing 0.1s latency each.
- **Baseline:** 2.02 seconds (executed roughly sequentially: 20 * 0.1s + tiny overhead).
- **Post-Optimization:** 0.10 seconds (executed concurrently: ~0.1s for all 20 together + tiny overhead).
- **Change over baseline:** Elapsed time dropped by a factor of 20 (a 95% reduction in total latency) for a batch of 20 elements. This scales wonderfully for larger sets of evaluation data as well!

---
*PR created automatically by Jules for task [1122249607312128950](https://jules.google.com/task/1122249607312128950) started by @JonathanRReed*