### PR TITLE
🧪 Add missing unit test for submit_sync in async ingest manager

### DIFF
--- a/api/tests/core/test_async_ingest.py
+++ b/api/tests/core/test_async_ingest.py
@@ -1,0 +1,20 @@
+from unittest.mock import Mock
+from app.core.async_ingest import AsyncIngestManager, JobStore, IngestJob
+
+def test_submit_sync():
+    mock_pipeline = Mock()
+    manager = AsyncIngestManager(pipeline=mock_pipeline)
+
+    # Mock the job store create method
+    mock_job = IngestJob(id="test_id", title="Test Job")
+    manager._job_store = Mock(spec=JobStore)
+    manager._job_store.create.return_value = mock_job
+
+    title = "Test Job"
+    content = b"Test content"
+    metadata = {"key": "value"}
+
+    result = manager.submit_sync(title=title, content=content, metadata=metadata)
+
+    manager._job_store.create.assert_called_once_with(title, content, metadata)
+    assert result == mock_job


### PR DESCRIPTION
🎯 **What:** 
Added a missing unit test for the `submit_sync` method in `AsyncIngestManager` (`api/app/core/async_ingest.py`). The function is simple and delegates to the inner `_job_store.create` function, but it was entirely untested.

📊 **Coverage:** 
- The test verifies that calling `submit_sync` correctly delegates to the mocked `JobStore.create`.
- The test verifies that arguments (`title`, `content`, `metadata`) are correctly passed to `create()`.
- The test verifies that the method returns the created `IngestJob` successfully.

✨ **Result:** 
- Improved test coverage for `AsyncIngestManager` by explicitly covering the `submit_sync` edge case.
- Ensures future refactoring or updates won't accidentally break synchronous submission.

---
*PR created automatically by Jules for task [9262266370799831390](https://jules.google.com/task/9262266370799831390) started by @JonathanRReed*